### PR TITLE
랭킹 API - 많이찾는 식당 랭킹 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/RankingController.java
+++ b/src/main/java/com/foodmate/backend/controller/RankingController.java
@@ -29,9 +29,10 @@ public class RankingController {
         return ResponseEntity.ok(rankingService.showMeetingRanking());
     }
 
+    // 많이찾는 식당 랭킹
     @GetMapping("/store")
-    public ResponseEntity<?> showStoreRanking() {
-        return ResponseEntity.ok("");
+    public ResponseEntity<List<RankingDto.Store>> showStoreRanking() {
+        return ResponseEntity.ok(rankingService.showStoreRanking());
     }
 
     @GetMapping("/food")

--- a/src/main/java/com/foodmate/backend/dto/RankingDto.java
+++ b/src/main/java/com/foodmate/backend/dto/RankingDto.java
@@ -23,4 +23,12 @@ public class RankingDto {
         private long count;
     }
 
+    @Getter
+    @Builder
+    public static class Store {
+        private String storeName;
+        private String address;
+        private long count;
+    }
+
 }

--- a/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
@@ -1,0 +1,23 @@
+package com.foodmate.backend.repository;
+
+import com.foodmate.backend.entity.FoodGroup;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FoodGroupRepository extends JpaRepository<FoodGroup, Long> {
+
+    // RankingServiceImpl - 많이찾는 식당 랭킹
+    @Query("SELECT fg.storeName, fg.storeAddress, COUNT(*) AS count " +
+            "FROM FoodGroup fg " +
+            "WHERE fg.groupDateTime < CURRENT_TIMESTAMP " +
+            "AND fg.isDeleted IS NULL " +
+            "GROUP BY fg.storeName, fg.storeAddress " +
+            "ORDER BY COUNT(*) DESC")
+    List<Object[]> findTop10StoreWithCount(Pageable pageable);
+
+}

--- a/src/main/java/com/foodmate/backend/repository/GroupRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/GroupRepository.java
@@ -1,9 +1,0 @@
-package com.foodmate.backend.repository;
-
-import com.foodmate.backend.entity.FoodGroup;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface GroupRepository extends JpaRepository<FoodGroup, Long> {
-}

--- a/src/main/java/com/foodmate/backend/service/RankingService.java
+++ b/src/main/java/com/foodmate/backend/service/RankingService.java
@@ -12,4 +12,7 @@ public interface RankingService {
     // 모임왕 랭킹
     List<RankingDto.Meeting> showMeetingRanking();
 
+    // 많이찾는 식당 랭킹
+    List<RankingDto.Store> showStoreRanking();
+
 }

--- a/src/main/java/com/foodmate/backend/service/impl/RankingServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/RankingServiceImpl.java
@@ -2,6 +2,7 @@ package com.foodmate.backend.service.impl;
 
 import com.foodmate.backend.dto.RankingDto;
 import com.foodmate.backend.entity.Member;
+import com.foodmate.backend.repository.FoodGroupRepository;
 import com.foodmate.backend.repository.MemberRepository;
 import com.foodmate.backend.service.RankingService;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import java.util.List;
 public class RankingServiceImpl implements RankingService {
 
     private final MemberRepository memberRepository;
+    private final FoodGroupRepository foodGroupRepository;
 
     // 좋아요 랭킹
     @Override
@@ -51,6 +53,25 @@ public class RankingServiceImpl implements RankingService {
                     .nickname((String) item[1])
                     .image((String) item[2])
                     .count((long) item[3])
+                    .build());
+        }
+
+        return result;
+    }
+
+    // 많이찾는 식당 랭킹
+    @Override
+    public List<RankingDto.Store> showStoreRanking() {
+
+        List<RankingDto.Store> result = new ArrayList<>();
+
+        List<Object[]> list = foodGroupRepository.findTop10StoreWithCount(PageRequest.of(0, 10));
+
+        for (Object[] item : list) {
+            result.add(RankingDto.Store.builder()
+                    .storeName((String) item[0])
+                    .address((String) item[1])
+                    .count((long) item[2])
                     .build());
         }
 


### PR DESCRIPTION
##  Feature

- 랭킹 API 중 많이찾는 식당 랭킹 기능 추가하였습니다.
( RankingController, RankingDto, RankingService, RankingServiceImpl, FoodGroupRepository )

- GroupRepository 이름을 FoodGroupRepository 로 변경하였습니다.

- FoodGroupRepository 의 식당 랭킹 쿼리 작성 시,
  상호와 주소를 그룹화하여, 두 가지가 동시에 일치해야만, 같은 식당으로 카운팅 되도록 하였습니다.

## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.

![image](https://github.com/withfoodmate/backend/assets/129507835/689e5124-3f89-47bd-825a-a91d62521716)

