### PR TITLE
카카오 로그인 API - 회원가입 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum Error {
 
+    DELETED_USER("이미 삭제된 유저입니다.", HttpStatus.UNAUTHORIZED),
     USER_NOT_FOUND("해당 아이디의 사용자가 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -11,6 +11,7 @@ public enum Error {
     DELETED_USER("이미 삭제된 유저입니다.", HttpStatus.UNAUTHORIZED),
     LOGIN_FAILED("로그인에 실패하였습니다.", HttpStatus.UNAUTHORIZED),
     AUTHORIZATION_NOT_FOUND("권한이 존재하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    LOGIN_REQUIRED("로그인이 필요합니다.",HttpStatus.UNAUTHORIZED),
     USER_NOT_FOUND("해당 아이디의 사용자가 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -10,6 +10,7 @@ public enum Error {
 
     DELETED_USER("이미 삭제된 유저입니다.", HttpStatus.UNAUTHORIZED),
     LOGIN_FAILED("로그인에 실패하였습니다.", HttpStatus.UNAUTHORIZED),
+    AUTHORIZATION_NOT_FOUND("권한이 존재하지 않습니다.", HttpStatus.UNAUTHORIZED),
     USER_NOT_FOUND("해당 아이디의 사용자가 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum Error {
 
     DELETED_USER("이미 삭제된 유저입니다.", HttpStatus.UNAUTHORIZED),
+    LOGIN_FAILED("로그인에 실패하였습니다.", HttpStatus.UNAUTHORIZED),
     USER_NOT_FOUND("해당 아이디의 사용자가 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;

--- a/src/main/java/com/foodmate/backend/enums/MemberLoginType.java
+++ b/src/main/java/com/foodmate/backend/enums/MemberLoginType.java
@@ -1,4 +1,6 @@
 package com.foodmate.backend.enums;
 
 public enum MemberLoginType {
+    KAKAO,
+    GENERAL
 }

--- a/src/main/java/com/foodmate/backend/enums/MemberRole.java
+++ b/src/main/java/com/foodmate/backend/enums/MemberRole.java
@@ -1,4 +1,6 @@
 package com.foodmate.backend.enums;
 
 public enum MemberRole {
+    USER,
+    ADMIN
 }

--- a/src/main/java/com/foodmate/backend/exception/AuthException.java
+++ b/src/main/java/com/foodmate/backend/exception/AuthException.java
@@ -1,0 +1,18 @@
+package com.foodmate.backend.exception;
+
+import com.foodmate.backend.enums.Error;
+import org.springframework.http.HttpStatus;
+
+public class AuthException extends RuntimeException {
+
+    private final Error error;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    public AuthException(Error error) {
+        this.error = error;
+        this.message = error.getMessage();
+        this.httpStatus = error.getHttpStatus();
+    }
+
+}

--- a/src/main/java/com/foodmate/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/foodmate/backend/security/config/SecurityConfig.java
@@ -1,0 +1,62 @@
+package com.foodmate.backend.security.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.foodmate.backend.repository.MemberRepository;
+import com.foodmate.backend.security.filter.ExceptionHandlerFilter;
+import com.foodmate.backend.security.filter.JwtAuthenticationProcessingFilter;
+import com.foodmate.backend.security.filter.handler.ApiAccessDeniedHandler;
+import com.foodmate.backend.security.filter.handler.ApiAuthenticationEntryPoint;
+import com.foodmate.backend.security.filter.handler.OAuth2LoginFailureHandler;
+import com.foodmate.backend.security.filter.handler.OAuth2LoginSuccessHandler;
+import com.foodmate.backend.security.service.JwtTokenProvider;
+import com.foodmate.backend.security.service.KakaoOAuth2MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Configuration
+@EnableWebSecurity(debug = true)
+@RequiredArgsConstructor
+@Slf4j
+public class SecurityConfig {
+
+    private final KakaoOAuth2MemberService kakaoOAuth2MemberService;
+    private final ObjectMapper objectMapper;
+    private final MemberRepository memberRepository;
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http
+                .csrf().disable()
+                .formLogin().disable()
+                .httpBasic().disable() // httpBasic 사용 X
+                .headers().frameOptions().disable()
+                .and()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http
+                .authorizeRequests()
+                .mvcMatchers("/test", "/test2").authenticated()
+                .anyRequest().permitAll();
+
+
+        return http.build();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring()
+                .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }
+}

--- a/src/main/java/com/foodmate/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/foodmate/backend/security/config/SecurityConfig.java
@@ -2,13 +2,6 @@ package com.foodmate.backend.security.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.foodmate.backend.repository.MemberRepository;
-import com.foodmate.backend.security.filter.ExceptionHandlerFilter;
-import com.foodmate.backend.security.filter.JwtAuthenticationProcessingFilter;
-import com.foodmate.backend.security.filter.handler.ApiAccessDeniedHandler;
-import com.foodmate.backend.security.filter.handler.ApiAuthenticationEntryPoint;
-import com.foodmate.backend.security.filter.handler.OAuth2LoginFailureHandler;
-import com.foodmate.backend.security.filter.handler.OAuth2LoginSuccessHandler;
-import com.foodmate.backend.security.service.JwtTokenProvider;
 import com.foodmate.backend.security.service.KakaoOAuth2MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,9 +13,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import javax.servlet.http.HttpServletResponse;
+
 
 @Configuration
 @EnableWebSecurity(debug = true)

--- a/src/main/java/com/foodmate/backend/security/config/SecurityOAuthConfig.java
+++ b/src/main/java/com/foodmate/backend/security/config/SecurityOAuthConfig.java
@@ -1,0 +1,27 @@
+package com.foodmate.backend.security.config;
+
+import com.foodmate.backend.repository.MemberRepository;
+import com.foodmate.backend.security.service.KakaoOAuth2MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityOAuthConfig {
+
+    private final MemberRepository memberRepository;
+
+    @Bean
+    public DefaultOAuth2UserService defaultOAuth2UserService() {
+        return new DefaultOAuth2UserService();
+    }
+
+    @Bean
+    KakaoOAuth2MemberService kakaoOAuth2MemberService() {
+        return new KakaoOAuth2MemberService(defaultOAuth2UserService(), memberRepository);
+    }
+}

--- a/src/main/java/com/foodmate/backend/security/filter/handler/ApiAccessDeniedHandler.java
+++ b/src/main/java/com/foodmate/backend/security/filter/handler/ApiAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package com.foodmate.backend.security.filter.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.foodmate.backend.enums.Error;
+import com.foodmate.backend.exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+
+@RequiredArgsConstructor
+@Slf4j
+public class ApiAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(objectMapper.writeValueAsString(new AuthException(Error.AUTHORIZATION_NOT_FOUND)));
+
+        log.error("ApiAccessDeniedHandler.handle: ", accessDeniedException);
+    }
+}

--- a/src/main/java/com/foodmate/backend/security/filter/handler/ApiAuthenticationEntryPoint.java
+++ b/src/main/java/com/foodmate/backend/security/filter/handler/ApiAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.foodmate.backend.security.filter.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.foodmate.backend.enums.Error;
+import com.foodmate.backend.exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+
+@RequiredArgsConstructor
+@Slf4j
+public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authenticationException) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(objectMapper.writeValueAsString(new AuthException(Error.LOGIN_REQUIRED)));
+
+        log.error("ApiAuthenticationEntryPoint.handle: ", authenticationException);
+    }
+
+}

--- a/src/main/java/com/foodmate/backend/security/filter/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/foodmate/backend/security/filter/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,27 @@
+package com.foodmate.backend.security.filter.handler;
+
+import com.foodmate.backend.enums.Error;
+import com.foodmate.backend.exception.AuthException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException{
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write(String.valueOf(new AuthException(Error.LOGIN_FAILED)));
+        log.info("로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+    }
+}

--- a/src/main/java/com/foodmate/backend/security/filter/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/foodmate/backend/security/filter/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,33 @@
+package com.foodmate.backend.security.filter.handler;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.getWriter().write("{ ☆ 로그인 성공 ☆ }");
+
+        log.info("로그인 성공");
+    }
+
+}

--- a/src/main/java/com/foodmate/backend/security/service/KakaoOAuth2MemberService.java
+++ b/src/main/java/com/foodmate/backend/security/service/KakaoOAuth2MemberService.java
@@ -1,6 +1,11 @@
 package com.foodmate.backend.security.service;
 
 
+import com.foodmate.backend.entity.Member;
+import com.foodmate.backend.enums.Error;
+import com.foodmate.backend.enums.MemberLoginType;
+import com.foodmate.backend.enums.MemberRole;
+import com.foodmate.backend.exception.MemberException;
 import com.foodmate.backend.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,13 +16,16 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Slf4j
 public class KakaoOAuth2MemberService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final DefaultOAuth2UserService userService;
+    private final MemberRepository memberRepository;
 
     @Override
     @Transactional
@@ -30,8 +38,42 @@ public class KakaoOAuth2MemberService implements OAuth2UserService<OAuth2UserReq
         Map<String, Object> memberInfo = oAuth2User.getAttribute("kakao_account");
         String email = (String) memberInfo.get("email");
         log.info(email);
+        if(isDeleteMember(email)){
+            throw new MemberException(Error.DELETED_USER);
+        }
+        saveUser(email);
 
         return oAuth2User;
+    }
+
+    /**
+     *
+     * @param email
+     * @return
+     * 이미 탈퇴한 기록이 있으면 true
+     * 아니면 false
+     */
+    private boolean isDeleteMember(String email) {
+        Optional<Member> memberOptional = memberRepository.findByEmail(email);
+        return memberOptional.isPresent() && memberOptional.get().getIsDeleted() != null;
+    }
+
+    private void saveUser(String email) {
+        Optional<Member> memberOptional = memberRepository.findByEmail(email);
+
+        if (memberOptional.isEmpty()) {
+            memberRepository.save(
+                    Member.builder()
+                            .email(email)
+                            .emailAuthDate(LocalDateTime.now())
+                            .isEmailAuth(true)
+                            .nickname(null)
+                            .memberRole(MemberRole.USER)
+                            .memberLoginType(MemberLoginType.KAKAO)
+                            .registeredDate(LocalDateTime.now())
+                            .build()
+            );
+        }
     }
 
 


### PR DESCRIPTION
##  Feature

- 최초로 카카오 로그인을 진행한 경우 회원가입이 진행 되도록 구현했습니다.
- Security 설정을 통해 접근 권한을 설정했습니다.
- 권한, 인증 관련 필터를 커스텀하여 실패 시, 응답을 내려주는 형식으로 설정했습니다.
  (기존에는 권한, 인증 실패 시 리다이렉트 주소로 이동)

## Test

- [ ] 테스트 코드
- [x] API 테스트

![image](https://github.com/withfoodmate/backend/assets/66156319/2dd38781-0d29-4752-837f-6708bcdce520)
최초 로그인 후 회원가입 완료

### SecurityFilterChain을 학습하며 정리한 내용입니다.

인증에 필요한 부분은 SecurityFilterChain을 거친다.

만약, 권한이 없거나 인증이 되지 않은 상태라면 해당 내용을 API로 내려줘야 하는데 기존에 구현되어 있는 코드로 인해 로그인 페이지로 자동 리다이렉트가 되버린다.

이렇게 되면 프론트 측에서는 어떤 이유 때문에 로그인 페이지로 이동되는지 알 수도 없고, 응답을 내려주는게 백엔드의 역할이기에 리다이렉트 시켜주는 필터를 찾아서 응답을 내려주는 필터로 커스텀 해주기로 했다.

### Security filter 확인

![image](https://github.com/withfoodmate/backend/assets/66156319/d11c3136-454f-4a4a-aa2b-d17cee4ae42c)

Security 디버그를 설정하여 확인을 해본 결과 ExceptionTranslationFilter에 로그인 페이지로 리다이렉트 시키는 기능이 있는걸 확인했다.

![image](https://github.com/withfoodmate/backend/assets/66156319/d52febf5-4c45-4a90-95f9-b0f1378bfb49)

handleSpringSecurityException 메서드를 보면 AuthenticationException은 인증 예외, AccessDeniedException은 권한 거부 예외와 관련된 내용이라고 짐작할 수 있다.

## 1. AccessDeniedException

![image](https://github.com/withfoodmate/backend/assets/66156319/9b592a78-37c2-4b08-933c-6e242912bbdf)

### AccessDeniedHandler

![image](https://github.com/withfoodmate/backend/assets/66156319/ab995f53-c4bc-425c-a6e8-e04d25972039)

### AccessDeniedHandlerImpl (AccessDeniedHandler의 구현체)

![image](https://github.com/withfoodmate/backend/assets/66156319/da1902b7-cc42-4758-911a-9759a7f5d5b1)

request.getRequestDispatcher(this.errorPage).forward(request, response); 부분에 의해

자동적으로 로그인 페이지로 리다이렉트가 된다고 판단했다.

> RequestDispatcher란?
> 바인딩을 하여 데이터까지 해당 주소로 넘겨주는 기능

이 부분을 커스텀 해보자.

### ApiAccessDeniedHandler (직접 만든 클래스)

![image](https://github.com/withfoodmate/backend/assets/66156319/9d236e08-2eb3-4136-b1f1-160365d49a72)

로그인 페이지로 리다이렉트 시키는 기능이 아닌, 응답을 내려주는 코드를 설정해줬다.

## 2. AuthenticationException

![image](https://github.com/withfoodmate/backend/assets/66156319/218e1903-b198-4f6b-b967-c8c0bc6ea5fc)

### AuthenticationEntryPoint

![image](https://github.com/withfoodmate/backend/assets/66156319/f1d76993-d6cf-4020-b2c4-0efa96d57028)

### Http403ForbiddenEntryPoint (AuthenticationEntryPoint 구현체)

![image](https://github.com/withfoodmate/backend/assets/66156319/fd2bcf24-3be8-46c1-a017-10758322849b)

AuthenticationException이 발생하면 Http403ForbiddenEntryPoint에서 처리하는걸 확인했다.

이 부분을 커스텀해서 응답으로 내려주자

### ApiAuthenticationEntryPoint (직접 만든 클래스)
![image](https://github.com/withfoodmate/backend/assets/66156319/1ae8b192-c9f5-4425-92ab-896da4ebca8d)