### PR TITLE
JWT 토큰 발급 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/entity/Member.java
+++ b/src/main/java/com/foodmate/backend/entity/Member.java
@@ -51,4 +51,9 @@ public class Member {
 
     private String refreshToken;
 
+
+    public void updateRefreshToken(String updateRefreshToken) {
+        this.refreshToken = updateRefreshToken;
+    }
+
 }

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -12,6 +12,7 @@ public enum Error {
     LOGIN_FAILED("로그인에 실패하였습니다.", HttpStatus.UNAUTHORIZED),
     AUTHORIZATION_NOT_FOUND("권한이 존재하지 않습니다.", HttpStatus.UNAUTHORIZED),
     LOGIN_REQUIRED("로그인이 필요합니다.",HttpStatus.UNAUTHORIZED),
+    TOKEN_INVALID("유효하지 않은 토큰 입니다.", HttpStatus.UNAUTHORIZED),
     USER_NOT_FOUND("해당 아이디의 사용자가 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;

--- a/src/main/java/com/foodmate/backend/repository/MemberRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/MemberRepository.java
@@ -17,6 +17,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     // 이메일을 통해 회원 찾기
     Optional<Member> findByEmail(String email);
+
+    // RefreshToken 정보 찾기
+    Optional<Member> findByRefreshToken(String refreshToken);
   
     // RankingServiceImpl - 모임왕 랭킹
     @Query("SELECT m.id, m.nickname, m.image, COUNT(fg.member) AS count " +

--- a/src/main/java/com/foodmate/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/foodmate/backend/security/config/SecurityConfig.java
@@ -2,6 +2,13 @@ package com.foodmate.backend.security.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.foodmate.backend.repository.MemberRepository;
+import com.foodmate.backend.security.filter.ExceptionHandlerFilter;
+import com.foodmate.backend.security.filter.JwtAuthenticationProcessingFilter;
+import com.foodmate.backend.security.filter.handler.ApiAccessDeniedHandler;
+import com.foodmate.backend.security.filter.handler.ApiAuthenticationEntryPoint;
+import com.foodmate.backend.security.filter.handler.OAuth2LoginFailureHandler;
+import com.foodmate.backend.security.filter.handler.OAuth2LoginSuccessHandler;
+import com.foodmate.backend.security.service.JwtTokenProvider;
 import com.foodmate.backend.security.service.KakaoOAuth2MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +20,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 
 @Configuration
@@ -25,6 +32,9 @@ public class SecurityConfig {
     private final KakaoOAuth2MemberService kakaoOAuth2MemberService;
     private final ObjectMapper objectMapper;
     private final MemberRepository memberRepository;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final JwtTokenProvider jwtTokenProvider;
 
 
     @Bean
@@ -41,6 +51,20 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .mvcMatchers("/test", "/test2").authenticated()
                 .anyRequest().permitAll();
+        http
+                .oauth2Login()
+                .userInfoEndpoint().userService(kakaoOAuth2MemberService)
+                .and()
+                .successHandler(oAuth2LoginSuccessHandler)
+                .failureHandler(oAuth2LoginFailureHandler);
+
+        // 필터 순서를 설정하여 정상작동 및 Filter에서 예외처리 진행
+        http
+                .addFilterBefore(new JwtAuthenticationProcessingFilter(jwtTokenProvider, memberRepository), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new ExceptionHandlerFilter(objectMapper), JwtAuthenticationProcessingFilter.class)
+                .exceptionHandling()
+                .authenticationEntryPoint(new ApiAuthenticationEntryPoint(objectMapper)) //AuthenticationException
+                .accessDeniedHandler(new ApiAccessDeniedHandler(objectMapper));     //AccessDeniedException
 
 
         return http.build();

--- a/src/main/java/com/foodmate/backend/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/foodmate/backend/security/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,46 @@
+package com.foodmate.backend.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.foodmate.backend.enums.Error;
+import com.foodmate.backend.exception.AuthException;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+
+//Filter 에서 올라오는 예외 처리 담당,
+//주로 JwtAuthenticationProcessingFilter 예외 처리
+
+@RequiredArgsConstructor
+@Slf4j
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtException  e) {
+            handleJwtException(response, e);
+        }
+    }
+
+    private void handleJwtException(HttpServletResponse response, JwtException e) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(objectMapper.writeValueAsString(new AuthException(Error.TOKEN_INVALID)));
+        log.error("JwtException 발생", e);
+    }
+}

--- a/src/main/java/com/foodmate/backend/security/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/foodmate/backend/security/filter/JwtAuthenticationProcessingFilter.java
@@ -1,0 +1,120 @@
+package com.foodmate.backend.security.filter;
+
+import com.foodmate.backend.entity.Member;
+import com.foodmate.backend.enums.Error;
+import com.foodmate.backend.exception.AuthException;
+import com.foodmate.backend.repository.MemberRepository;
+import com.foodmate.backend.security.service.JwtTokenProvider;
+import com.foodmate.backend.util.PasswordUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+
+/**
+ * [Jwt 인증 필터]
+ *
+ * 기본적으로 사용자는 요청 헤더에 AccessToken만 담아서 요청
+ * AccessToken 만료 시에만 RefreshToken을 요청 헤더에 담아서 요청
+ *
+ * 1. RefreshToken이 헤더에 없고, AccessToken이 유효한 경우 -> 인증 성공 처리, RefreshToken을 재발급하지는 않는다.
+ * 2. RefreshToken이 헤더에 없고, AccessToken이 없거나 유효하지 않은 경우 -> 인증 실패 처리 (토큰 관련 예외는 ExceptionHandlerFilter에서 처리)
+ * 3. RefreshToken이 헤더에 있는 경우 -> DB의 RefreshToken과 비교하여 일치하면 AccessToken, RefreshToken 재발급(RTR 방식)
+ * 인증 성공 처리는 하지 않고 실패 처리
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
+
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+    private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String refreshToken = jwtTokenProvider.extractRefreshToken(request)
+                .filter(jwtTokenProvider::isTokenValid)
+                .orElse(null);
+
+        if (refreshToken != null) {
+            checkRefreshTokenAndReIssueAccessAndRefreshToken(response, refreshToken);
+            return; // RefreshToken을 보낸 경우에는 AccessToken & RefreshToken을 재발급 해주는 메서드 호출, 인증 처리는 하지 않게 하기위해 바로 return으로 필터 진행 막기
+        }
+
+        checkAccessTokenAndAuthentication(request);
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * [RefreshToken 토큰으로 유저 정보 찾기 & 액세스 토큰/리프레시 토큰 재발급]
+     */
+    public void checkRefreshTokenAndReIssueAccessAndRefreshToken(HttpServletResponse response, String refreshToken) {
+        Member member = memberRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new AuthException(Error.TOKEN_INVALID));
+
+        String reIssuedRefreshToken = reIssueRefreshToken(member);
+        jwtTokenProvider.sendAccessAndRefreshToken(response, jwtTokenProvider.createAccessToken(member.getId()),
+                reIssuedRefreshToken);
+
+    }
+
+    /**
+     * [RefreshToken 토큰 재발급 & DB에 업데이트]
+     */
+    private String reIssueRefreshToken(Member member) {
+        String reIssuedRefreshToken = jwtTokenProvider.createRefreshToken();
+        member.updateRefreshToken(reIssuedRefreshToken);
+        memberRepository.saveAndFlush(member);
+        return reIssuedRefreshToken;
+    }
+
+    /**
+     * [액세스 토큰 체크 & 인증 처리]
+     */
+    public void checkAccessTokenAndAuthentication(HttpServletRequest request) throws ServletException, IOException {
+        log.info("checkAccessTokenAndAuthentication() 호출");
+        jwtTokenProvider.extractAccessToken(request)
+                .filter(jwtTokenProvider::isTokenValid)
+                .ifPresent(accessToken -> jwtTokenProvider.extractId(accessToken)
+                        .ifPresent(id -> memberRepository.findById(id)
+                                .ifPresent(this::setAuthentication)));
+    }
+
+    /**
+     * [인증 허가]
+     */
+    public void setAuthentication(Member member) {
+        String password = member.getPassword();
+        if (password == null) { // 소셜 로그인 유저의 비밀번호 임의로 설정 하여 인증 되도록 설정
+            password = PasswordUtil.generateRandomPassword();
+        }
+
+        UserDetails userDetailsUser = User.builder()
+                .username(member.getEmail())
+                .password(password)
+                .roles(member.getMemberRole().name())
+                .build();
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userDetailsUser, null,
+                        authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/foodmate/backend/security/filter/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/foodmate/backend/security/filter/handler/OAuth2LoginSuccessHandler.java
@@ -1,10 +1,16 @@
 package com.foodmate.backend.security.filter.handler;
 
 
+import com.foodmate.backend.entity.Member;
+import com.foodmate.backend.enums.Error;
+import com.foodmate.backend.exception.MemberException;
+import com.foodmate.backend.repository.MemberRepository;
+import com.foodmate.backend.security.service.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -12,22 +18,41 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
+        OAuth2User memberInfo = (OAuth2User) authentication.getPrincipal();
+        String email = (String) ((Map) memberInfo.getAttribute("kakao_account")).get("email");
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(Error.USER_NOT_FOUND));
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+
+        loginSuccess(response, accessToken, refreshToken, member);
 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setStatus(HttpServletResponse.SC_OK);
         response.getWriter().write("{ ☆ 로그인 성공 ☆ }");
 
-        log.info("로그인 성공");
+    }
+
+    private void loginSuccess(HttpServletResponse response, String accessToken, String refreshToken, Member member){
+        response.addHeader(jwtTokenProvider.getAccessHeader(), "Bearer " + accessToken);
+        response.addHeader(jwtTokenProvider.getRefreshHeader(), "Bearer " + refreshToken);
+
+        jwtTokenProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+        jwtTokenProvider.updateRefreshToken(member.getEmail(), refreshToken);
     }
 
 }

--- a/src/main/java/com/foodmate/backend/security/service/JwtTokenProvider.java
+++ b/src/main/java/com/foodmate/backend/security/service/JwtTokenProvider.java
@@ -1,0 +1,167 @@
+package com.foodmate.backend.security.service;
+
+
+import com.foodmate.backend.entity.Member;
+import com.foodmate.backend.repository.MemberRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.security.Key;
+import java.util.Date;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@Getter
+public class JwtTokenProvider {
+
+    private Key key;
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+
+    @Value("${jwt.refresh.header}")
+    private String refreshHeader;
+
+    private final MemberRepository memberRepository;
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey, MemberRepository memberRepository) {
+        byte[] bytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(bytes);
+
+        this.memberRepository = memberRepository;
+    }
+
+    public static final String MEMBER_ID = "memberId";
+
+
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;    // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14; // 14일
+
+
+    /**
+     * Access 토큰 생성
+     */
+    public String createAccessToken(Long memberId) {
+        Claims claims = Jwts.claims();
+        claims.put(MEMBER_ID, memberId);
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * Refresh 토큰 생성
+     */
+    public String createRefreshToken() {
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+    }
+
+    /**
+     * AccessToken + RefreshToken 헤더에 실어서 전송
+     */
+    public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        setAccessTokenHeader(response, accessToken);
+        setRefreshTokenHeader(response, refreshToken);
+
+        log.info("access 토큰 : " + accessToken);
+        log.info("refresh 토큰 : " + refreshToken);
+    }
+
+    /**
+     * 헤더에서 AccessToken 추출
+     * 토큰 형식 : Bearer XXX에서 Bearer를 제외하고 순수 토큰만 가져오기 위해서
+     * 헤더를 가져온 후 "Bearer"를 삭제(""로 replace)
+     */
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(accessHeader))
+                .filter(accessToken -> accessToken.startsWith("Bearer "))
+                .map(accessToken -> accessToken.replace("Bearer ", ""));
+    }
+
+    /**
+     * 헤더에서 RefreshToken 추출
+     * 토큰 형식 : Bearer XXX에서 Bearer를 제외하고 순수 토큰만 가져오기 위해서
+     * 헤더를 가져온 후 "Bearer"를 삭제하기(""로 replace 진행)
+     */
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(refreshHeader))
+                .filter(refreshToken -> refreshToken.startsWith("Bearer "))
+                .map(refreshToken -> refreshToken.replace("Bearer ", ""));
+    }
+
+    /**
+     * AccessToken에서 Email 추출
+     */
+    public Optional<Long> extractId(String accessToken) {
+        Jws<Claims> claimsJws = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(accessToken);
+
+        // Email 클레임 추출
+        Long idClaim = claimsJws.getBody().get(MEMBER_ID, Long.class);
+        return Optional.ofNullable(idClaim);
+    }
+
+    /**
+     * AccessToken 헤더 설정
+     */
+    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+        response.setHeader(accessHeader, accessToken);
+    }
+
+    /**
+     * RefreshToken 헤더 설정
+     */
+    public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
+        response.setHeader(refreshHeader, refreshToken);
+    }
+
+    /**
+     * RefreshToken DB 저장(업데이트)
+     */
+    @Transactional
+    public void updateRefreshToken(String email, String refreshToken) {
+        Optional<Member> memberOptional = memberRepository.findByEmail(email);
+        Member member = memberOptional.get();
+        member.updateRefreshToken(refreshToken);
+    }
+
+    /**
+     * Token 유효성 검사
+     */
+    public boolean isTokenValid(String token) {
+        Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+        return true;
+    }
+}

--- a/src/main/java/com/foodmate/backend/util/PasswordUtil.java
+++ b/src/main/java/com/foodmate/backend/util/PasswordUtil.java
@@ -1,0 +1,33 @@
+package com.foodmate.backend.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Random;
+
+@Slf4j
+public class PasswordUtil {
+
+    public static String generateRandomPassword() {
+        int index = 0;
+        char[] charSet = new char[] {
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+                'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+                'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+        };	//배열안의 문자 숫자는 원하는대로
+
+        StringBuffer password = new StringBuffer();
+        Random random = new Random();
+
+        for (int i = 0; i < 8 ; i++) {
+            double rd = random.nextDouble();
+            index = (int) (charSet.length * rd);
+
+            password.append(charSet[index]);
+        }
+        log.info(String.valueOf(password));
+        return password.toString();
+        //StringBuffer를 String으로 변환해서 return 하려면 toString()을 사용하면 된다.
+    }
+}


### PR DESCRIPTION
##  Feature

- 카카오 로그인 성공 시 JWT 토큰 발급(Access, Refresh) 기능 추가하였습니다.
- Refresh 토큰은 로컬 DB에 저장했습니다. 추후에 시간이 되면 Redis에 Refresh토큰을 저장해볼 생각입니다!
- JWT 토큰 관련 예외가 발생 하면 응답을 내려주도록 처리했습니다.
- JWT, OAuth2 관련 Security 설정을 했습니다.


## Test

- [ ] 테스트 코드
- [x] API 테스트

- Jwt 인증 필터 로직 설명

  기본적으로 사용자는 요청 헤더에 AccessToken만 담아서 요청
  AccessToken 만료 시에만 RefreshToken을 요청 헤더에 담아서 요청
 
  1. RefreshToken이 헤더에 없고, AccessToken이 유효한 경우 -> 인증 성공 처리, RefreshToken을 재발급하지는 않는다.
  2. RefreshToken이 헤더에 없고, AccessToken이 없거나 유효하지 않은 경우 -> 인증 실패 처리 (토큰 관련 예외는 ExceptionHandlerFilter에서 처리)
  3. RefreshToken이 헤더에 있는 경우 -> DB의 RefreshToken과 비교하여 일치하면 AccessToken, RefreshToken 재발급(RTR 방식)
  인증 성공 처리는 하지 않고 실패 처리
