### PR TITLE
그룹 API - 모임 상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/GroupController.java
+++ b/src/main/java/com/foodmate/backend/controller/GroupController.java
@@ -5,10 +5,7 @@ import com.foodmate.backend.service.GroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -24,6 +21,12 @@ public class GroupController {
     public ResponseEntity<String> addGroup(Authentication authentication,
                                            @RequestBody @Valid GroupDto.Request request) {
         return ResponseEntity.ok(groupService.addGroup(authentication, request));
+    }
+
+    // 특정 모임 상세 조회
+    @GetMapping("/{groupId}")
+    public ResponseEntity<GroupDto.DetailResponse> getGroupDetail(@PathVariable Long groupId) {
+        return ResponseEntity.ok(groupService.getGroupDetail(groupId));
     }
 
 }

--- a/src/main/java/com/foodmate/backend/dto/GroupDto.java
+++ b/src/main/java/com/foodmate/backend/dto/GroupDto.java
@@ -1,12 +1,16 @@
 package com.foodmate.backend.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.foodmate.backend.entity.ChatRoom;
+import com.foodmate.backend.entity.FoodGroup;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public class GroupDto {
@@ -29,6 +33,55 @@ public class GroupDto {
         private String storeAddress;
         private String latitude;
         private String longitude;
+    }
+
+    @Getter
+    @Builder
+    public static class DetailResponse {
+        private Long groupId;
+        private Long memberId;
+        private String nickname;
+        private String image;
+        private String title;
+        private String name;
+        private String content;
+        private String food;
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        private LocalDate date;
+        @JsonFormat(pattern = "HH:mm", timezone = "Asia/Seoul")
+        private LocalTime time;
+        private int maximum;
+        private int current;
+        private String storeName;
+        private String storeAddress;
+        private String latitude;
+        private String longitude;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        private LocalDateTime createdDate;
+        private Long chatRoomId;
+
+        public static DetailResponse fromEntity(FoodGroup foodGroup, int current, ChatRoom chatRoom) {
+            return DetailResponse.builder()
+                    .groupId(foodGroup.getId())
+                    .memberId(foodGroup.getMember().getId())
+                    .nickname(foodGroup.getMember().getNickname())
+                    .image(foodGroup.getMember().getImage())
+                    .title(foodGroup.getTitle())
+                    .name(foodGroup.getName())
+                    .content(foodGroup.getContent())
+                    .food(foodGroup.getFood().getType())
+                    .date(foodGroup.getGroupDateTime().toLocalDate())
+                    .time(foodGroup.getGroupDateTime().toLocalTime())
+                    .maximum(foodGroup.getMaximum())
+                    .current(current)
+                    .storeName(foodGroup.getStoreName())
+                    .storeAddress(foodGroup.getStoreAddress())
+                    .latitude(Double.toString(foodGroup.getLocation().getY()))
+                    .longitude(Double.toString(foodGroup.getLocation().getX()))
+                    .createdDate(foodGroup.getCreatedDate())
+                    .chatRoomId(chatRoom.getId())
+                    .build();
+        }
     }
 
 }

--- a/src/main/java/com/foodmate/backend/entity/Enrollment.java
+++ b/src/main/java/com/foodmate/backend/entity/Enrollment.java
@@ -1,4 +1,40 @@
 package com.foodmate.backend.entity;
 
+import com.foodmate.backend.enums.EnrollmentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
 public class Enrollment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Member member;
+
+    @ManyToOne
+    private FoodGroup foodGroup;
+
+    @CreatedDate
+    private LocalDateTime enrollDate;
+
+    @Enumerated(EnumType.STRING)
+    private EnrollmentStatus status;
+
+    @LastModifiedDate
+    private LocalDateTime decisionDate;
+
 }

--- a/src/main/java/com/foodmate/backend/enums/EnrollmentStatus.java
+++ b/src/main/java/com/foodmate/backend/enums/EnrollmentStatus.java
@@ -1,4 +1,10 @@
 package com.foodmate.backend.enums;
 
 public enum EnrollmentStatus {
+    SUBMIT,          // 신청완료
+    CANCEL,          // 신청취소
+    ACCEPT,          // 수락
+    REFUSE,          // 거절
+    GROUP_CANCEL,    // 모임취소
+    GROUP_COMPLETE   // 모임완료
 }

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -12,7 +12,7 @@ public enum Error {
     DELETED_USER("이미 삭제된 유저입니다.", HttpStatus.UNAUTHORIZED),
     LOGIN_FAILED("로그인에 실패하였습니다.", HttpStatus.UNAUTHORIZED),
     AUTHORIZATION_NOT_FOUND("권한이 존재하지 않습니다.", HttpStatus.UNAUTHORIZED),
-    LOGIN_REQUIRED("로그인이 필요합니다.",HttpStatus.UNAUTHORIZED),
+    LOGIN_REQUIRED("로그인이 필요합니다.", HttpStatus.UNAUTHORIZED),
     TOKEN_INVALID("유효하지 않은 토큰 입니다.", HttpStatus.UNAUTHORIZED),
     USER_NOT_FOUND("해당 아이디의 사용자가 없습니다.", HttpStatus.NOT_FOUND),
 
@@ -20,7 +20,12 @@ public enum Error {
     FOOD_NOT_FOUND("입력한 음식은 DB에 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // GroupException
-    OUT_OF_DATE_RANGE("현재 시간으로부터 한 시간 이후 ~ 한 달 이내의 모임만 생성 가능합니다.", HttpStatus.BAD_REQUEST);
+    OUT_OF_DATE_RANGE("현재 시간으로부터 한 시간 이후 ~ 한 달 이내의 모임만 생성 가능합니다.", HttpStatus.BAD_REQUEST),
+    GROUP_NOT_FOUND("해당 아이디의 모임은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    GROUP_DELETED("해당 모임은 삭제되었습니다.", HttpStatus.GONE),
+
+    // ChatException
+    CHATROOM_NOT_FOUND("해당 모임 아이디의 채팅룸은 존재하지 않습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/foodmate/backend/exception/ChatException.java
+++ b/src/main/java/com/foodmate/backend/exception/ChatException.java
@@ -1,4 +1,20 @@
 package com.foodmate.backend.exception;
 
-public class ChatException extends RuntimeException{
+import com.foodmate.backend.enums.Error;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ChatException extends RuntimeException {
+
+    private final Error error;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    public ChatException(Error error) {
+        this.error = error;
+        this.message = error.getMessage();
+        this.httpStatus = error.getHttpStatus();
+    }
+
 }

--- a/src/main/java/com/foodmate/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/foodmate/backend/exception/GlobalExceptionHandler.java
@@ -29,6 +29,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(e.getHttpStatus()).body(e.getMessage());
     }
 
+    @ExceptionHandler(ChatException.class)
+    public ResponseEntity<String> handleChatException(ChatException e) {
+        log.error("ChatException", e);
+        return ResponseEntity.status(e.getHttpStatus()).body(e.getMessage());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException", e);

--- a/src/main/java/com/foodmate/backend/repository/ChatRoomRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/ChatRoomRepository.java
@@ -4,6 +4,12 @@ import com.foodmate.backend.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    // 모임 아이디로 채팅방 찾기
+    Optional<ChatRoom> findByFoodGroupId(Long groupId);
+
 }

--- a/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
@@ -1,9 +1,14 @@
 package com.foodmate.backend.repository;
 
 import com.foodmate.backend.entity.Enrollment;
+import com.foodmate.backend.enums.EnrollmentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EnrollmentRepository extends JpaRepository<Enrollment,Long> {
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+
+    // 모임의 현재 참여인원 카운트할 때 사용
+    int countByFoodGroupIdAndStatus(Long groupId, EnrollmentStatus status);
+
 }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -7,4 +7,6 @@ public interface GroupService {
 
     String addGroup(Authentication authentication, GroupDto.Request request);
 
+    GroupDto.DetailResponse getGroupDetail(Long groupId);
+
 }


### PR DESCRIPTION
##  Feature

- 그룹 API - 모임 상세 조회 기능 추가하였습니다.
( GroupController, GroupDto.DetailResponse, GroupService, 
 EnrollmentRepository, ChatRoomRepository, GroupServiceImpl )

- 기능 추가에 필요하여 Enrollment 엔티티와 EnrollmentStatus 이넘 작성하였습니다.

- 기능 추가에 필요한 ChatException 작성하고, GlobalExceptionHandler 에 추가하였습니다.

- 기능 추가에 필요한 Error 이넘 작성하였습니다.

## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.

![image](https://github.com/withfoodmate/backend/assets/129507835/45faead5-3e02-4a06-981b-dd81e941d7b8)



