### PR TITLE
그룹 API - 모임 삭제 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/GroupController.java
+++ b/src/main/java/com/foodmate/backend/controller/GroupController.java
@@ -37,4 +37,11 @@ public class GroupController {
         return ResponseEntity.ok(groupService.updateGroup(groupId, authentication, request));
     }
 
+    // 특정 모임 삭제
+    @DeleteMapping("/{groupId}")
+    public ResponseEntity<String> deleteGroup(@PathVariable Long groupId,
+                                              Authentication authentication) {
+        return ResponseEntity.ok(groupService.deleteGroup(groupId, authentication));
+    }
+
 }

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -24,6 +24,7 @@ public enum Error {
     GROUP_NOT_FOUND("해당 아이디의 모임은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     GROUP_DELETED("해당 모임은 삭제되었습니다.", HttpStatus.GONE),
     NO_MODIFY_PERMISSION_GROUP("해당 모임을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    NO_DELETE_PERMISSION_GROUP("해당 모임을 삭제할 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
     // ChatException
     CHATROOM_NOT_FOUND("해당 모임 아이디의 채팅룸은 존재하지 않습니다.", HttpStatus.NOT_FOUND);

--- a/src/main/java/com/foodmate/backend/repository/ChatRoomRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/ChatRoomRepository.java
@@ -12,4 +12,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     // 모임 아이디로 채팅방 찾기
     Optional<ChatRoom> findByFoodGroupId(Long groupId);
 
+    // 모임 아이디로 채팅방 삭제
+    void deleteByFoodGroupId(Long groupId);
+
 }

--- a/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
@@ -3,6 +3,8 @@ package com.foodmate.backend.repository;
 import com.foodmate.backend.entity.Enrollment;
 import com.foodmate.backend.enums.EnrollmentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -10,5 +12,10 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     // 모임의 현재 참여인원 카운트할 때 사용
     int countByFoodGroupIdAndStatus(Long groupId, EnrollmentStatus status);
+
+    // 모임 삭제 후 Status 상태 모임취소로 일괄 변경할 때 사용
+    @Modifying
+    @Query("UPDATE Enrollment e SET e.status = :status WHERE e.foodGroup.id = :groupId")
+    void changeStatusByGroupId(Long groupId, EnrollmentStatus status);
 
 }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -11,4 +11,6 @@ public interface GroupService {
 
     String updateGroup(Long groupId, Authentication authentication, GroupDto.Request request);
 
+    String deleteGroup(Long groupId, Authentication authentication);
+
 }


### PR DESCRIPTION
##  Feature

- 그룹 API - 모임 삭제 기능 추가하였습니다.
( GroupController, GroupService, GroupServiceImpl )

- EnrollmentRepository 에 모임 삭제 후, 신청서 Status 를 모임취소로 일괄 변경하는 메소드를 작성하였습니다.

- ChatRoomRepository 에 모임 삭제 후, 채팅룸을 삭제하는 메소드를 작성하였습니다.

- 모임 삭제 기능에 필요한 Error 이넘 추가 작성하였습니다.

## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.

![image](https://github.com/withfoodmate/backend/assets/129507835/e82402f1-a935-4ee1-923a-bac3034d0505)

![image](https://github.com/withfoodmate/backend/assets/129507835/f4d5155d-a479-4d16-9661-e367f9016844)





