### PR TITLE
유저 API - 닉네임 중복 검사 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/MemberController.java
+++ b/src/main/java/com/foodmate/backend/controller/MemberController.java
@@ -51,4 +51,15 @@ public class MemberController {
         return ResponseEntity.ok(memberService.checkDuplicateEmail(request.getEmail()));
     }
 
+
+    /**
+     * @param request 사용자가 입력한 nickname
+     * @return 현재 사용중인 nickname이면 false
+     *         아니면 true
+     */
+    @GetMapping("/nickname")
+    public ResponseEntity<Boolean> checkDuplicateNickname(@RequestBody MemberDto.Request request){
+        return ResponseEntity.ok(memberService.checkDuplicateNickname(request.getNickname()));
+    }
+
 }

--- a/src/main/java/com/foodmate/backend/dto/MemberDto.java
+++ b/src/main/java/com/foodmate/backend/dto/MemberDto.java
@@ -15,6 +15,7 @@ public class MemberDto {
     @AllArgsConstructor
     public static class Request{
         private String email;
+        private String nickname;
     }
 
     @Getter

--- a/src/main/java/com/foodmate/backend/repository/MemberRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/MemberRepository.java
@@ -17,7 +17,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     // 이메일을 통해 회원 찾기
     Optional<Member> findByEmail(String email);
-
+    // 닉네임을 통해 회원 찾기
+    Optional<Member> findByNickname(String nickname);
     // RefreshToken 정보 찾기
     Optional<Member> findByRefreshToken(String refreshToken);
   

--- a/src/main/java/com/foodmate/backend/service/MemberService.java
+++ b/src/main/java/com/foodmate/backend/service/MemberService.java
@@ -10,5 +10,8 @@ public interface MemberService {
 
     MemberDto.Response getMemberInfo(Authentication authentication);
     Boolean checkDuplicateEmail(String email);
+
     String patchProfileImage(Authentication authentication, MultipartFile imageFile) throws IOException;
+
+    Boolean checkDuplicateNickname(String nickname);
 }

--- a/src/main/java/com/foodmate/backend/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/MemberServiceImpl.java
@@ -149,4 +149,17 @@ public class MemberServiceImpl implements MemberService {
         }
         return true;
     }
+
+    /**
+     * @param nickname
+     * @return 현재 사용중인 nickname 이면 false 리턴
+     *         아니면 true
+     */
+    @Override
+    public Boolean checkDuplicateNickname(String nickname) {
+        if(memberRepository.findByNickname(nickname).isPresent()){
+            return false;
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
##Feature 
닉네임 중복검사 기능 추가

##Test
- [ ] 테스트코드
- [x] API 테스트 
 
이미 존재 하는 닉네임 false
![image](https://github.com/withfoodmate/backend/assets/48889083/a832075d-29fb-41e1-a076-dc02123b114b)

사용 가능 닉네임 true
![image](https://github.com/withfoodmate/backend/assets/48889083/2aa3898f-ab2c-4a40-b853-072af8cea5b6)