### PR TITLE
그룹 API - 댓글 수정 & 대댓글 수정 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/GroupController.java
+++ b/src/main/java/com/foodmate/backend/controller/GroupController.java
@@ -70,4 +70,23 @@ public class GroupController {
         return ResponseEntity.ok(groupService.addReply(groupId, commentId, authentication, request));
     }
 
+    // 댓글 수정
+    @PutMapping("/{groupId}/comment/{commentId}")
+    public ResponseEntity<String> updateComment(@PathVariable Long groupId,
+                                                @PathVariable Long commentId,
+                                                Authentication authentication,
+                                                @RequestBody @Valid CommentDto.Request request) {
+        return ResponseEntity.ok(groupService.updateComment(groupId, commentId, authentication, request));
+    }
+
+    // 대댓글 수정
+    @PutMapping("/{groupId}/comment/{commentId}/reply/{replyId}")
+    public ResponseEntity<String> updateReply(@PathVariable Long groupId,
+                                              @PathVariable Long commentId,
+                                              @PathVariable Long replyId,
+                                              Authentication authentication,
+                                              @RequestBody @Valid ReplyDto.Request request) {
+        return ResponseEntity.ok(groupService.updateReply(groupId, commentId, replyId, authentication, request));
+    }
+
 }

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -35,7 +35,12 @@ public enum Error {
 
     // CommentException
     COMMENT_NOT_FOUND("해당 아이디의 댓글은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
-    INVALID_ADDRESS("올바르지 않은 주소입니다.", HttpStatus.BAD_REQUEST);
+    INVALID_ADDRESS("올바르지 않은 주소입니다.", HttpStatus.BAD_REQUEST),
+    NO_MODIFY_PERMISSION_COMMENT("해당 댓글을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+
+    // ReplyException
+    REPLY_NOT_FOUND("해당 아이디의 대댓글은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    NO_MODIFY_PERMISSION_REPLY("해당 대댓글을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/foodmate/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/foodmate/backend/exception/GlobalExceptionHandler.java
@@ -47,6 +47,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(e.getHttpStatus()).body(e.getMessage());
     }
 
+    @ExceptionHandler(ReplyException.class)
+    public ResponseEntity<String> handleReplyException(ReplyException e) {
+        log.error("ReplyException", e);
+        return ResponseEntity.status(e.getHttpStatus()).body(e.getMessage());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException", e);

--- a/src/main/java/com/foodmate/backend/exception/ReplyException.java
+++ b/src/main/java/com/foodmate/backend/exception/ReplyException.java
@@ -1,4 +1,20 @@
 package com.foodmate.backend.exception;
 
-public class ReplyException extends RuntimeException{
+import com.foodmate.backend.enums.Error;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ReplyException extends RuntimeException {
+
+    private final Error error;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    public ReplyException(Error error) {
+        this.error = error;
+        this.message = error.getMessage();
+        this.httpStatus = error.getHttpStatus();
+    }
+
 }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -21,4 +21,8 @@ public interface GroupService {
 
     String addReply(Long groupId, Long commentId, Authentication authentication, ReplyDto.Request request);
 
+    String updateComment(Long groupId, Long commentId, Authentication authentication, CommentDto.Request request);
+
+    String updateReply(Long groupId, Long commentId, Long replyId, Authentication authentication, ReplyDto.Request request);
+
 }


### PR DESCRIPTION
##  Feature

- 그룹 API - 댓글 수정 & 대댓글 수정 기능 추가하였습니다.
( GroupController, GroupService, GroupServiceImpl )

- ReplyException 작성하고 GlobalExceptionHandler 에 추가하였습니다.

- 댓글/대댓글 수정 기능에 필요한 Error 이넘 작성하였습니다.

## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.

![image](https://github.com/withfoodmate/backend/assets/129507835/ee09ffc3-b6a2-4fe9-aece-e1e75bad0aa0)





