### PR TITLE
그룹 API - 댓글 삭제 & 대댓글 삭제 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/GroupController.java
+++ b/src/main/java/com/foodmate/backend/controller/GroupController.java
@@ -89,4 +89,21 @@ public class GroupController {
         return ResponseEntity.ok(groupService.updateReply(groupId, commentId, replyId, authentication, request));
     }
 
+    // 댓글 삭제
+    @DeleteMapping("/{groupId}/comment/{commentId}")
+    public ResponseEntity<String> deleteComment(@PathVariable Long groupId,
+                                                @PathVariable Long commentId,
+                                                Authentication authentication) {
+        return ResponseEntity.ok(groupService.deleteComment(groupId, commentId, authentication));
+    }
+
+    // 대댓글 삭제
+    @DeleteMapping("/{groupId}/comment/{commentId}/reply/{replyId}")
+    public ResponseEntity<String> deleteReply(@PathVariable Long groupId,
+                                              @PathVariable Long commentId,
+                                              @PathVariable Long replyId,
+                                              Authentication authentication) {
+        return ResponseEntity.ok(groupService.deleteReply(groupId, commentId, replyId, authentication));
+    }
+
 }

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -37,10 +37,12 @@ public enum Error {
     COMMENT_NOT_FOUND("해당 아이디의 댓글은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     INVALID_ADDRESS("올바르지 않은 주소입니다.", HttpStatus.BAD_REQUEST),
     NO_MODIFY_PERMISSION_COMMENT("해당 댓글을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    NO_DELETE_PERMISSION_COMMENT("해당 댓글을 삭제할 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
     // ReplyException
     REPLY_NOT_FOUND("해당 아이디의 대댓글은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
-    NO_MODIFY_PERMISSION_REPLY("해당 대댓글을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN);
+    NO_MODIFY_PERMISSION_REPLY("해당 대댓글을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    NO_DELETE_PERMISSION_REPLY("해당 대댓글을 삭제할 권한이 없습니다.", HttpStatus.FORBIDDEN);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/foodmate/backend/repository/ReplyRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/ReplyRepository.java
@@ -1,9 +1,14 @@
 package com.foodmate.backend.repository;
 
+import com.foodmate.backend.entity.Comment;
 import com.foodmate.backend.entity.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ReplyRepository extends JpaRepository<Reply,Long> {
+public interface ReplyRepository extends JpaRepository<Reply, Long> {
+
+    // 해당 댓글의 대댓글 일괄 삭제
+    void deleteAllByComment(Comment comment);
+
 }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -25,4 +25,8 @@ public interface GroupService {
 
     String updateReply(Long groupId, Long commentId, Long replyId, Authentication authentication, ReplyDto.Request request);
 
+    String deleteComment(Long groupId, Long commentId, Authentication authentication);
+
+    String deleteReply(Long groupId, Long commentId, Long replyId, Authentication authentication);
+
 }

--- a/src/main/java/com/foodmate/backend/service/impl/GroupServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/GroupServiceImpl.java
@@ -259,6 +259,49 @@ public class GroupServiceImpl implements GroupService {
         return "대댓글 수정 완료";
     }
 
+    // 댓글 삭제
+    @Transactional
+    @Override
+    public String deleteComment(Long groupId, Long commentId, Authentication authentication) {
+
+        validateGroupId(groupId);
+        Comment comment = validateCommentId(groupId, commentId);
+
+        Member member = getMember(authentication);
+
+        // 해당 댓글 작성자만 삭제 가능
+        if (comment.getMember().getId() != member.getId()) {
+            throw new CommentException(Error.NO_DELETE_PERMISSION_COMMENT);
+        }
+
+        // 우선 해당 댓글의 대댓글 일괄 삭제해야 댓글 삭제 가능
+        replyRepository.deleteAllByComment(comment);
+
+        commentRepository.deleteById(commentId);
+
+        return "댓글 삭제 완료";
+    }
+
+    // 대댓글 삭제
+    @Override
+    public String deleteReply(Long groupId, Long commentId, Long replyId, Authentication authentication) {
+
+        validateGroupId(groupId);
+        validateCommentId(groupId, commentId);
+        Reply reply = validateReplyId(commentId, replyId);
+
+        Member member = getMember(authentication);
+
+        // 해당 대댓글 작성자만 삭제 가능
+        if (reply.getMember().getId() != member.getId()) {
+            throw new ReplyException(Error.NO_DELETE_PERMISSION_REPLY);
+        }
+
+        replyRepository.deleteById(replyId);
+
+        return "대댓글 삭제 완료";
+    }
+
     // {groupId} 경로 검증 - 존재하는 그룹이면서, 삭제되지 않은 경우만 반환
     private FoodGroup validateGroupId(Long groupId) {
 


### PR DESCRIPTION
##  Feature

- 그룹 API - 댓글 삭제 & 대댓글 삭제 기능 추가하였습니다.
( GroupController, GroupService, GroupServiceImpl )

- 댓글 삭제를 하려면, 해당 댓글의 대댓글들을 일괄 삭제해야 합니다.
  위 메소드를 ReplyRepository 에 작성하였습니다.

- 댓글/대댓글 삭제 기능에 필요한 Error 이넘 작성하였습니다.

## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.

![image](https://github.com/withfoodmate/backend/assets/129507835/39630fab-8d44-45f9-89b4-76a9c9e6a8ec)






