### PR TITLE
그룹 API - 댓글 대댓글 전체 조회 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/GroupController.java
+++ b/src/main/java/com/foodmate/backend/controller/GroupController.java
@@ -5,6 +5,8 @@ import com.foodmate.backend.dto.GroupDto;
 import com.foodmate.backend.dto.ReplyDto;
 import com.foodmate.backend.service.GroupService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -104,6 +106,12 @@ public class GroupController {
                                               @PathVariable Long replyId,
                                               Authentication authentication) {
         return ResponseEntity.ok(groupService.deleteReply(groupId, commentId, replyId, authentication));
+    }
+
+    // 댓글 대댓글 전체 조회
+    @GetMapping("{groupId}/comment")
+    public ResponseEntity<Page<CommentDto.Response>> getComments(@PathVariable Long groupId, Pageable pageable) {
+        return ResponseEntity.ok(groupService.getComments(groupId, pageable));
     }
 
 }

--- a/src/main/java/com/foodmate/backend/dto/CommentDto.java
+++ b/src/main/java/com/foodmate/backend/dto/CommentDto.java
@@ -1,10 +1,15 @@
 package com.foodmate.backend.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.foodmate.backend.entity.Comment;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class CommentDto {
 
@@ -14,6 +19,34 @@ public class CommentDto {
     @AllArgsConstructor
     public static class Request {
         private String content;
+    }
+
+    @Getter
+    @Builder
+    public static class Response {
+        private Long commentId;
+        private Long memberId;
+        private String nickname;
+        private String image;
+        private String content;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        private LocalDateTime createdDate;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        private LocalDateTime updatedDate;
+        private List<ReplyDto.Response> replies;
+
+        public static Response fromEntity(Comment comment, List<ReplyDto.Response> replies) {
+            return Response.builder()
+                    .commentId(comment.getId())
+                    .memberId(comment.getMember().getId())
+                    .nickname(comment.getMember().getNickname())
+                    .image(comment.getMember().getImage())
+                    .content(comment.getContent())
+                    .createdDate(comment.getCreatedDate())
+                    .updatedDate(comment.getUpdatedDate())
+                    .replies(replies)
+                    .build();
+        }
     }
 
 }

--- a/src/main/java/com/foodmate/backend/dto/ReplyDto.java
+++ b/src/main/java/com/foodmate/backend/dto/ReplyDto.java
@@ -1,10 +1,14 @@
 package com.foodmate.backend.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.foodmate.backend.entity.Reply;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
 public class ReplyDto {
 
@@ -14,6 +18,32 @@ public class ReplyDto {
     @AllArgsConstructor
     public static class Request {
         private String content;
+    }
+
+    @Getter
+    @Builder
+    public static class Response {
+        private Long replyId;
+        private Long memberId;
+        private String nickname;
+        private String image;
+        private String content;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        private LocalDateTime createdDate;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        private LocalDateTime updatedDate;
+
+        public static Response fromEntity(Reply reply) {
+            return Response.builder()
+                    .replyId(reply.getId())
+                    .memberId(reply.getMember().getId())
+                    .nickname(reply.getMember().getNickname())
+                    .image(reply.getMember().getImage())
+                    .content(reply.getContent())
+                    .createdDate(reply.getCreatedDate())
+                    .updatedDate(reply.getUpdatedDate())
+                    .build();
+        }
     }
 
 }

--- a/src/main/java/com/foodmate/backend/repository/CommentRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/CommentRepository.java
@@ -1,9 +1,16 @@
 package com.foodmate.backend.repository;
 
 import com.foodmate.backend.entity.Comment;
+import com.foodmate.backend.entity.FoodGroup;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CommentRepository extends JpaRepository<Comment,Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    // 해당 모임의 댓글 전체 조회
+    Page<Comment> findAllByFoodGroup(FoodGroup foodGroup, Pageable pageable);
+
 }

--- a/src/main/java/com/foodmate/backend/repository/ReplyRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/ReplyRepository.java
@@ -5,10 +5,15 @@ import com.foodmate.backend.entity.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
     // 해당 댓글의 대댓글 일괄 삭제
     void deleteAllByComment(Comment comment);
+
+    // 해당 댓글의 대댓글 전체 조회
+    List<Reply> findAllByComment(Comment comment);
 
 }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -3,6 +3,8 @@ package com.foodmate.backend.service;
 import com.foodmate.backend.dto.CommentDto;
 import com.foodmate.backend.dto.GroupDto;
 import com.foodmate.backend.dto.ReplyDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 
 public interface GroupService {
@@ -28,5 +30,7 @@ public interface GroupService {
     String deleteComment(Long groupId, Long commentId, Authentication authentication);
 
     String deleteReply(Long groupId, Long commentId, Long replyId, Authentication authentication);
+
+    Page<CommentDto.Response> getComments(Long groupId, Pageable pageable);
 
 }


### PR DESCRIPTION
##  Feature

- 그룹 API - 댓글 대댓글 전체 조회 기능 추가하였습니다.
( GroupController, GroupService, GroupServiceImpl )

- 댓글 / 대댓글 응답을 위해 CommentDto.Response / ReplyDto.Response 를 작성하였습니다.

- 댓글 / 대댓글 조회 메소드를 CommentRepository / ReplyRepository 에 작성하였습니다.

- 페이징 처리하였습니다.

## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.

![image](https://github.com/withfoodmate/backend/assets/129507835/5ed85037-04ce-4f62-bb1b-8f5d786269e9)







