### PR TITLE
회원 API - 일반 로그인 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/MemberController.java
+++ b/src/main/java/com/foodmate/backend/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.foodmate.backend.controller;
 
 import com.foodmate.backend.dto.MemberDto;
+import com.foodmate.backend.security.dto.JwtTokenDto;
 import com.foodmate.backend.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/foodmate/backend/controller/MemberController.java
+++ b/src/main/java/com/foodmate/backend/controller/MemberController.java
@@ -12,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -120,5 +121,12 @@ public class MemberController {
         return ResponseEntity.ok(memberService.toggleLikeForPost(memberId, authentication));
     }
 
+    /**
+     * 이메일, 패스워드 입력
+     */
+    @PostMapping("/signin")
+    public ResponseEntity<JwtTokenDto> login(@RequestBody Map<String, String> user) {
+        return ResponseEntity.ok(memberService.login(user));
+    }
 
 }

--- a/src/main/java/com/foodmate/backend/security/dto/JwtTokenDto.java
+++ b/src/main/java/com/foodmate/backend/security/dto/JwtTokenDto.java
@@ -1,0 +1,17 @@
+package com.foodmate.backend.security.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class JwtTokenDto {
+
+    private final String accessToken;
+    private final String refreshToken;
+
+    @Builder
+    public JwtTokenDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/foodmate/backend/service/MemberService.java
+++ b/src/main/java/com/foodmate/backend/service/MemberService.java
@@ -1,12 +1,14 @@
 package com.foodmate.backend.service;
 
 import com.foodmate.backend.dto.MemberDto;
+import com.foodmate.backend.security.dto.JwtTokenDto;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Map;
 
 public interface MemberService {
 
@@ -28,4 +30,6 @@ public interface MemberService {
     boolean emailAuth(String emailAuthKey);
 
     String toggleLikeForPost(Long memberId, Authentication authentication);
+
+    JwtTokenDto login(Map<String, String> loginInfo);
 }

--- a/src/main/java/com/foodmate/backend/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/MemberServiceImpl.java
@@ -14,6 +14,8 @@ import com.foodmate.backend.repository.FoodRepository;
 import com.foodmate.backend.repository.LikesRepository;
 import com.foodmate.backend.repository.MemberRepository;
 import com.foodmate.backend.repository.PreferenceRepository;
+import com.foodmate.backend.security.dto.JwtTokenDto;
+import com.foodmate.backend.security.service.JwtTokenProvider;
 import com.foodmate.backend.service.MemberService;
 import com.foodmate.backend.util.FileRandomNaming;
 import com.foodmate.backend.util.S3Deleter;
@@ -50,6 +52,8 @@ public class MemberServiceImpl implements MemberService {
     @Value("${S3_GENERAL_IMAGE_PATH}")
     private String defaultProfileImage;
     private final MailComponents mailComponents;
+    private final JwtTokenProvider jwtTokenProvider;
+
     /**
      * @param authentication 로그인한 사용자의 정보
      * @return 사용자의 정보
@@ -337,4 +341,26 @@ public class MemberServiceImpl implements MemberService {
         }
     }
 
+    @Override
+    public JwtTokenDto login(Map<String, String> loginInfo) {
+        String email = loginInfo.get("email");
+        String password = loginInfo.get("password");
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(Error.USER_NOT_FOUND));
+        if (!BCrypt.checkpw(password, member.getPassword())) {
+            log.info(password);
+            log.info(member.getPassword());
+            throw new MemberException(Error.LOGIN_FAILED);
+        }
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+
+        JwtTokenDto jwtTokenDto = JwtTokenDto.builder()
+                .accessToken(jwtTokenProvider.createAccessToken(member.getId()))
+                .refreshToken(refreshToken)
+                .build();
+        jwtTokenProvider.updateRefreshToken(member.getEmail(), refreshToken);
+
+        return jwtTokenDto;
+    }
 }

--- a/src/main/java/com/foodmate/backend/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/MemberServiceImpl.java
@@ -33,10 +33,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.transaction.Transactional;
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.StringTokenizer;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -52,7 +49,7 @@ public class MemberServiceImpl implements MemberService {
     private final String s3BucketFolderName = "profile-images/";
     @Value("${S3_GENERAL_IMAGE_PATH}")
     private String defaultProfileImage;
-
+    private final MailComponents mailComponents;
     /**
      * @param authentication 로그인한 사용자의 정보
      * @return 사용자의 정보


### PR DESCRIPTION
##  Feature

- 회원 API - 일반 로그인 기능 추가했습니다.

- JWT 토큰으로 로그인 방식을 유지하기 위해 로그인 성공 시, JWT 토큰을 발급하도록 했습니다. (Access Token, Refresh Token)


## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.

![image](https://github.com/withfoodmate/backend/assets/66156319/691404a4-fcec-4180-b505-0a82464b9296)





