### PR TITLE
유저 API - 회원탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/MemberController.java
+++ b/src/main/java/com/foodmate/backend/controller/MemberController.java
@@ -94,7 +94,6 @@ public class MemberController {
     @PostMapping("/signup")
     public ResponseEntity<String> createMember(@RequestPart MemberDto.CreateMemberRequest request,
                                                @RequestPart(value = "file", required = false) MultipartFile imageFile) throws IOException {
-
         if(imageFile == null){ // 이미지가 없을 때
             return ResponseEntity.ok(memberService.createDefaultImageMember(request));
         }
@@ -138,7 +137,24 @@ public class MemberController {
      */
     @PatchMapping("/password")
     public ResponseEntity<String> changePassword(@RequestBody MemberDto.passwordUpdateRequest request, Authentication authentication) {
-        log.error(request.getOldPassword());
         return ResponseEntity.ok(memberService.changePassword(request, authentication));
+    }
+
+
+    /**
+     * @param request 로그아웃을 위한
+     * @param response 로그아웃을 위한  response
+     * @param authentication 현재 로그인한 사용자의 정보
+     * @param deleteMemberRequest 사용자가 입력한 password
+     * @return 회원탈퇴 상태 호출
+     */
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteMember(HttpServletRequest request, HttpServletResponse response, Authentication authentication,
+                                               @RequestBody(required = false) MemberDto.deleteMemberRequest deleteMemberRequest) {
+        if (deleteMemberRequest == null) {
+            return ResponseEntity.ok(memberService.deleteKakaoMember(request, response, authentication));
+        } else {
+            return ResponseEntity.ok(memberService.deleteGeneralMember(request, response, authentication, deleteMemberRequest));
+        }
     }
 }

--- a/src/main/java/com/foodmate/backend/dto/MemberDto.java
+++ b/src/main/java/com/foodmate/backend/dto/MemberDto.java
@@ -68,4 +68,12 @@ public class MemberDto {
         private String oldPassword;
         private String newPassword;
     }
+
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class deleteMemberRequest{
+        private String password;
+    }
 }

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -16,6 +16,7 @@ public enum Error {
     TOKEN_INVALID("유효하지 않은 토큰 입니다.", HttpStatus.UNAUTHORIZED),
     USER_NOT_FOUND("해당 사용자가 없습니다.", HttpStatus.NOT_FOUND),
     PASSWORD_NOT_MATCH("패스워드가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    ACCESS_DENIED("해당 요청에 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
     // FoodException
     FOOD_NOT_FOUND("입력한 음식은 DB에 존재하지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/foodmate/backend/service/MemberService.java
+++ b/src/main/java/com/foodmate/backend/service/MemberService.java
@@ -34,4 +34,12 @@ public interface MemberService {
     JwtTokenDto login(Map<String, String> loginInfo);
 
     String changePassword(MemberDto.passwordUpdateRequest request, Authentication authentication);
+
+    String deleteKakaoMember(HttpServletRequest request, HttpServletResponse response, Authentication authentication);
+
+    String deleteGeneralMember(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication,
+            MemberDto.deleteMemberRequest deleteMemberRequest);
 }

--- a/src/main/java/com/foodmate/backend/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/MemberServiceImpl.java
@@ -397,7 +397,7 @@ public class MemberServiceImpl implements MemberService {
     public String deleteKakaoMember(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         Member member = memberRepository.findByEmail(authentication.getName())
                 .orElseThrow(() -> new MemberException(Error.USER_NOT_FOUND));
-
+        logout(request, response);
         member.setIsDeleted(LocalDateTime.now());
         memberRepository.save(member);
         return "회원 탈퇴 성공";


### PR DESCRIPTION
##Feature
 - 회원 탈퇴 기능 추가 (Controller, Service, ServiceImpl, Dto, Error)
 - 회원 탈퇴 시 일반사용자 카카오로그인 사용자 분류해서 처리
 
##Test
 - [ ] 테스트코드
 - [x] API 테스트
 
![image](https://github.com/withfoodmate/backend/assets/48889083/17921e0f-0f2d-48c1-826d-f9aa72b435e1)

