### PR TITLE
그룹 API - 오늘의 모임 조회 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/GroupController.java
+++ b/src/main/java/com/foodmate/backend/controller/GroupController.java
@@ -122,4 +122,10 @@ public class GroupController {
         return ResponseEntity.ok(groupService.searchByKeyword(keyword, pageable));
     }
 
+    // 오늘 모임 조회
+    @GetMapping("/today")
+    public ResponseEntity<Page<SearchedGroupDto>> getTodayGroupList(Pageable pageable) {
+        return ResponseEntity.ok(groupService.getTodayGroupList(pageable));
+    }
+
 }

--- a/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
@@ -39,4 +39,19 @@ public interface FoodGroupRepository extends JpaRepository<FoodGroup, Long> {
             "ORDER BY fg.createdDate DESC")
     Page<SearchedGroupDto> searchByKeyword(String keyword, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
+    // GroupServiceImpl - 오늘 모임 조회
+    @Query("SELECT new com.foodmate.backend.dto.SearchedGroupDto(" +
+            "fg.id, fg.title, fg.name, fg.groupDateTime, fg.maximum, fg.storeName, fg.storeAddress, fg.createdDate, " +
+            "m.id, m.nickname, m.image, f.type, COUNT(e.id)) " +
+            "FROM FoodGroup fg " +
+            "JOIN Member m ON fg.member.id = m.id " +
+            "JOIN Food f ON fg.food.id = f.id " +
+            "LEFT JOIN Enrollment e ON fg.id = e.foodGroup.id AND e.status = 'ACCEPT' " +
+            "WHERE fg.groupDateTime BETWEEN :start AND :end " +
+            "AND fg.isDeleted IS NULL " +
+            "GROUP BY fg.id, fg.title, fg.name, fg.groupDateTime, fg.maximum, fg.storeName, fg.storeAddress, fg.createdDate, " +
+            "m.id, m.nickname, m.image, f.type " +
+            "ORDER BY fg.groupDateTime ASC")
+    Page<SearchedGroupDto> getTodayGroupList(LocalDateTime start, LocalDateTime end, Pageable pageable);
+
 }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -36,4 +36,6 @@ public interface GroupService {
 
     Page<SearchedGroupDto> searchByKeyword(String keyword, Pageable pageable);
 
+    Page<SearchedGroupDto> getTodayGroupList(Pageable pageable);
+
 }

--- a/src/main/java/com/foodmate/backend/service/impl/GroupServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/GroupServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -343,6 +344,14 @@ public class GroupServiceImpl implements GroupService {
         return foodGroupRepository.searchByKeyword(keyword,
                 LocalDateTime.now().plusMinutes(SEARCH_INTERVAL_MINUTE),
                 LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH), pageable);
+    }
+
+    // 오늘 모임 조회
+    @Override
+    public Page<SearchedGroupDto> getTodayGroupList(Pageable pageable) {
+
+        return foodGroupRepository.getTodayGroupList(LocalDateTime.now(),
+                LocalDate.now().atTime(23, 59, 59), pageable);
     }
 
     // {groupId} 경로 검증 - 존재하는 그룹이면서, 삭제되지 않은 경우만 반환


### PR DESCRIPTION
##  Feature

- 그룹 API - 오늘의 모임 조회 기능 추가하였습니다.
( GroupController, GroupService, GroupServiceImpl )

- 오늘 모임 조회를 위한 쿼리를 FoodGroupRepository 에 작성하였습니다. (정렬은 모임일시 기준 오름차순)

- 페이징 처리하였습니다.

## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.

![image](https://github.com/withfoodmate/backend/assets/129507835/e0d30342-e4a0-47ea-b83b-545795d6770e)









