### PR TITLE
신청 API - 본인이 생성한 모든 모임 요청 조회 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/EnrollmentController.java
+++ b/src/main/java/com/foodmate/backend/controller/EnrollmentController.java
@@ -28,4 +28,15 @@ public class EnrollmentController {
     public ResponseEntity<Page<EnrollmentDto>> getMyEnrollment(@RequestParam String status, Authentication authentication, Pageable pageable){
         return ResponseEntity.ok(enrollmentService.getMyEnrollment(status, authentication, pageable));
     }
+
+    /**
+     *
+     * @param decision 처리 상태
+     * @param authentication 사용자 정보
+     * @return 처리 상태에 따른 정보 가져옴
+     */
+    @GetMapping("/receive")
+    public ResponseEntity<Page<EnrollmentDto.RequestList>> enrollmentList(@RequestParam String decision, Authentication authentication) {
+        return ResponseEntity.ok(enrollmentService.enrollmentList(decision, authentication));
+    }
 }

--- a/src/main/java/com/foodmate/backend/controller/EnrollmentController.java
+++ b/src/main/java/com/foodmate/backend/controller/EnrollmentController.java
@@ -36,7 +36,7 @@ public class EnrollmentController {
      * @return 처리 상태에 따른 정보 가져옴
      */
     @GetMapping("/receive")
-    public ResponseEntity<Page<EnrollmentDto.RequestList>> enrollmentList(@RequestParam String decision, Authentication authentication) {
-        return ResponseEntity.ok(enrollmentService.enrollmentList(decision, authentication));
+    public ResponseEntity<Page<EnrollmentDto.RequestList>> enrollmentList(@RequestParam String decision, Authentication authentication, Pageable pageable) {
+        return ResponseEntity.ok(enrollmentService.enrollmentList(decision, authentication, pageable));
     }
 }

--- a/src/main/java/com/foodmate/backend/dto/EnrollmentDto.java
+++ b/src/main/java/com/foodmate/backend/dto/EnrollmentDto.java
@@ -42,6 +42,15 @@ public class EnrollmentDto {
         this.storeAddress = storeAddress;
         this.status = status;
     }
+
+    @Getter
+    @Builder
+    public static class RequestList {
+        private Long enrollmentId;
+        private Long memberId;
+        private String nickname;
+        private String image;
+    }
 }
 
 

--- a/src/main/java/com/foodmate/backend/dto/EnrollmentDto.java
+++ b/src/main/java/com/foodmate/backend/dto/EnrollmentDto.java
@@ -7,7 +7,9 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
@@ -47,9 +49,18 @@ public class EnrollmentDto {
     @Builder
     public static class RequestList {
         private Long enrollmentId;
+        private Long groupId;
         private Long memberId;
         private String nickname;
         private String image;
+        private String title;
+        private String name;
+        private String food;
+        private LocalDate date;
+        private LocalTime time;
+        private int maximum;
+        private String storeName;
+        private String storeAddress;
     }
 }
 

--- a/src/main/java/com/foodmate/backend/entity/Enrollment.java
+++ b/src/main/java/com/foodmate/backend/entity/Enrollment.java
@@ -3,6 +3,7 @@ package com.foodmate.backend.entity;
 import com.foodmate.backend.enums.EnrollmentStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Getter
 @Entity
 public class Enrollment {
 

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -34,6 +34,7 @@ public enum Error {
     // EnrollmentException
     ENROLLMENT_HISTORY_EXISTS("해당 모임에 신청 이력이 존재합니다.", HttpStatus.BAD_REQUEST),
     GROUP_FULL("해당 모임의 정원이 다 찼습니다.", HttpStatus.BAD_REQUEST),
+    REQUEST_NOT_FOUND("입력한 요청이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
     // CommentException
     COMMENT_NOT_FOUND("해당 아이디의 댓글은 존재하지 않습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
@@ -51,7 +51,7 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     @Query("SELECT e FROM Enrollment e " +
             "JOIN e.foodGroup fg " +
             "WHERE fg.member.id = :id " +
-            "AND e.status = 'SUBMIT' " +
+            "AND e.status = 'ACCEPT' " +
             "ORDER BY e.enrollDate ASC")
     Page<Enrollment> findByMyEnrollmentProcessedList(@Param("id") Long readerId, Pageable pageable);
 
@@ -59,7 +59,7 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     @Query("SELECT e FROM Enrollment e " +
             "JOIN e.foodGroup fg " +
             "WHERE fg.member.id = :id " +
-            "AND e.status = 'ACCEPT' " +
+            "AND e.status = 'SUBMIT' " +
             "ORDER BY e.enrollDate ASC")
     Page<Enrollment> findByMyEnrollmentUnprocessedList(@Param("id") Long readerId, Pageable pageable);
 }

--- a/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
@@ -47,7 +47,7 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
             LocalDateTime endDateTime,
             Pageable pageable);
 
-    // 본인이 생성한 모든 모임의 요청 중 신청완료인 리스트 조회
+    // 본인이 생성한 모든 모임의 요청 중 수락한 리스트 조회
     @Query("SELECT e FROM Enrollment e " +
             "JOIN e.foodGroup fg " +
             "WHERE fg.member.id = :id " +
@@ -55,7 +55,7 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
             "ORDER BY e.enrollDate ASC")
     Page<Enrollment> findByMyEnrollmentProcessedList(@Param("id") Long readerId, Pageable pageable);
 
-    // 본인이 생성한 모든 모임의 요청 중 수락한 리스트 조회
+    // 본인이 생성한 모든 모임의 요청 중 신청완료인 리스트 조회
     @Query("SELECT e FROM Enrollment e " +
             "JOIN e.foodGroup fg " +
             "WHERE fg.member.id = :id " +

--- a/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
@@ -46,4 +46,20 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
             LocalDateTime startDateTime,
             LocalDateTime endDateTime,
             Pageable pageable);
+
+    // 본인이 생성한 모든 모임의 요청 중 신청완료인 리스트 조회
+    @Query("SELECT e FROM Enrollment e " +
+            "JOIN e.foodGroup fg " +
+            "WHERE fg.member.id = :id " +
+            "AND e.status = 'SUBMIT' " +
+            "ORDER BY e.enrollDate ASC")
+    Page<Enrollment> findByMyEnrollmentProcessedList(@Param("id") Long readerId, Pageable pageable);
+
+    // 본인이 생성한 모든 모임의 요청 중 수락한 리스트 조회
+    @Query("SELECT e FROM Enrollment e " +
+            "JOIN e.foodGroup fg " +
+            "WHERE fg.member.id = :id " +
+            "AND e.status = 'ACCEPT' " +
+            "ORDER BY e.enrollDate ASC")
+    Page<Enrollment> findByMyEnrollmentUnprocessedList(@Param("id") Long readerId, Pageable pageable);
 }

--- a/src/main/java/com/foodmate/backend/service/EnrollmentService.java
+++ b/src/main/java/com/foodmate/backend/service/EnrollmentService.java
@@ -9,5 +9,5 @@ public interface EnrollmentService {
 
     Page<EnrollmentDto> getMyEnrollment(String status, Authentication authentication, Pageable pageable);
 
-    Page<EnrollmentDto.RequestList> enrollmentList(String decision, Authentication authentication);
+    Page<EnrollmentDto.RequestList> enrollmentList(String decision, Authentication authentication, Pageable pageable);
 }

--- a/src/main/java/com/foodmate/backend/service/EnrollmentService.java
+++ b/src/main/java/com/foodmate/backend/service/EnrollmentService.java
@@ -8,4 +8,6 @@ import org.springframework.security.core.Authentication;
 public interface EnrollmentService {
 
     Page<EnrollmentDto> getMyEnrollment(String status, Authentication authentication, Pageable pageable);
+
+    Page<EnrollmentDto.RequestList> enrollmentList(String decision, Authentication authentication);
 }

--- a/src/main/java/com/foodmate/backend/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/EnrollmentServiceImpl.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Service

--- a/src/main/java/com/foodmate/backend/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/EnrollmentServiceImpl.java
@@ -54,9 +54,18 @@ public class EnrollmentServiceImpl implements EnrollmentService {
             enrollmentsPage = enrollmentRepository.findByMyEnrollmentProcessedList(member.getId(), PageRequest.of(0, 20));
             return enrollmentsPage.map(enrollment -> EnrollmentDto.RequestList.builder()
                     .enrollmentId(enrollment.getId())
+                    .groupId(enrollment.getFoodGroup().getId())
                     .memberId(enrollment.getMember().getId())
                     .nickname(enrollment.getMember().getNickname())
                     .image(enrollment.getMember().getImage())
+                    .title(enrollment.getFoodGroup().getTitle())
+                    .name(enrollment.getFoodGroup().getName())
+                    .food(enrollment.getFoodGroup().getFood().getType())
+                    .date(enrollment.getFoodGroup().getGroupDateTime().toLocalDate())
+                    .time(enrollment.getFoodGroup().getGroupDateTime().toLocalTime())
+                    .maximum(enrollment.getFoodGroup().getMaximum())
+                    .storeName(enrollment.getFoodGroup().getStoreName())
+                    .storeAddress(enrollment.getFoodGroup().getStoreAddress())
                     .build());
 
         } else if (decision.equals("unprocessed")) {

--- a/src/main/java/com/foodmate/backend/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/EnrollmentServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDateTime;
 
@@ -43,7 +44,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     }
 
     @Override
-    public Page<EnrollmentDto.RequestList> enrollmentList(String decision, Authentication authentication) {
+    public Page<EnrollmentDto.RequestList> enrollmentList(String decision, Authentication authentication, Pageable pageable) {
 
         Member member = memberRepository.findByEmail(authentication.getName())
                 .orElseThrow(() -> new MemberException(Error.USER_NOT_FOUND));
@@ -51,7 +52,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
         Page<Enrollment> enrollmentsPage;
 
         if (decision.equals("processed")) {
-            enrollmentsPage = enrollmentRepository.findByMyEnrollmentProcessedList(member.getId(), PageRequest.of(0, 20));
+            enrollmentsPage = enrollmentRepository.findByMyEnrollmentProcessedList(member.getId(), pageable);
             return enrollmentsPage.map(enrollment -> EnrollmentDto.RequestList.builder()
                     .enrollmentId(enrollment.getId())
                     .groupId(enrollment.getFoodGroup().getId())
@@ -69,7 +70,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
                     .build());
 
         } else if (decision.equals("unprocessed")) {
-            enrollmentsPage = enrollmentRepository.findByMyEnrollmentUnprocessedList(member.getId(), PageRequest.of(0, 20));
+            enrollmentsPage = enrollmentRepository.findByMyEnrollmentUnprocessedList(member.getId(), pageable);
             return enrollmentsPage.map(enrollment -> EnrollmentDto.RequestList.builder()
                     .enrollmentId(enrollment.getId())
                     .memberId(enrollment.getMember().getId())


### PR DESCRIPTION
##  Feature

- 신청API -  본인이 생성한 모든 모임 요청 조회 기능 추가하였습니다.

- 신청 처리가 안된 부분과 신청 처리가 완료된 부분으로 나누어 조회하도록 했습니다.
- 처리 상태는 수락(ACCEPT)상태만 보이도록 설정했습니다.
  - 신청 처리 : decision = processed
  - 신청 미처리 : decision = unprocessed


## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.
  - 미처리 상태 
![image](https://github.com/withfoodmate/backend/assets/66156319/61a08a08-6ba2-438d-824a-4255dcab603c)
  - 처리 상태 (미처리 상태 요청 수락 후 조회함)
![image](https://github.com/withfoodmate/backend/assets/66156319/d99846be-8a9b-4598-97b2-fc4708aba69e)






