### PR TITLE
신청 API - 모임 요청 수락 or 거절

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/EnrollmentController.java
+++ b/src/main/java/com/foodmate/backend/controller/EnrollmentController.java
@@ -7,10 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -38,5 +35,25 @@ public class EnrollmentController {
     @GetMapping("/receive")
     public ResponseEntity<Page<EnrollmentDto.RequestList>> enrollmentList(@RequestParam String decision, Authentication authentication, Pageable pageable) {
         return ResponseEntity.ok(enrollmentService.enrollmentList(decision, authentication, pageable));
+    }
+
+    /**
+     * 모임 요청 수락
+     * @param enrollmentId 신청 id
+     * @return 처리 상태에 대한 응답
+     */
+    @PatchMapping("/{enrollmentId}/accept")
+    public ResponseEntity<String> acceptEnrollment(@PathVariable Long enrollmentId) {
+        return ResponseEntity.ok(enrollmentService.acceptEnrollment(enrollmentId));
+    }
+
+    /**
+     * 모임 요청 거절
+     * @param enrollmentId 신청 id
+     * @return 처리 상태에 대한 응답
+     */
+    @PatchMapping("/{enrollmentId}/refuse")
+    public ResponseEntity<String> refuseEnrollment(@PathVariable Long enrollmentId) {
+        return ResponseEntity.ok(enrollmentService.refuseEnrollment(enrollmentId));
     }
 }

--- a/src/main/java/com/foodmate/backend/entity/Enrollment.java
+++ b/src/main/java/com/foodmate/backend/entity/Enrollment.java
@@ -42,8 +42,5 @@ public class Enrollment {
     public void updateEnrollment(EnrollmentStatus status) {
         this.status = status;
     }
-    public void updateDecisionDate(LocalDateTime decisionDate) {
-        this.decisionDate = decisionDate;
-    }
 
 }

--- a/src/main/java/com/foodmate/backend/entity/Enrollment.java
+++ b/src/main/java/com/foodmate/backend/entity/Enrollment.java
@@ -39,4 +39,11 @@ public class Enrollment {
     @LastModifiedDate
     private LocalDateTime decisionDate;
 
+    public void updateEnrollment(EnrollmentStatus status) {
+        this.status = status;
+    }
+    public void updateDecisionDate(LocalDateTime decisionDate) {
+        this.decisionDate = decisionDate;
+    }
+
 }

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -35,6 +35,7 @@ public enum Error {
     ENROLLMENT_HISTORY_EXISTS("해당 모임에 신청 이력이 존재합니다.", HttpStatus.BAD_REQUEST),
     GROUP_FULL("해당 모임의 정원이 다 찼습니다.", HttpStatus.BAD_REQUEST),
     REQUEST_NOT_FOUND("입력한 요청이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    ENROLLMENT_NOT_FOUND("신청정보가 DB에 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
     // CommentException
     COMMENT_NOT_FOUND("해당 아이디의 댓글은 존재하지 않습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/foodmate/backend/service/EnrollmentService.java
+++ b/src/main/java/com/foodmate/backend/service/EnrollmentService.java
@@ -10,4 +10,8 @@ public interface EnrollmentService {
     Page<EnrollmentDto> getMyEnrollment(String status, Authentication authentication, Pageable pageable);
 
     Page<EnrollmentDto.RequestList> enrollmentList(String decision, Authentication authentication, Pageable pageable);
+
+    String acceptEnrollment(Long enrollmentId);
+
+    String refuseEnrollment(Long enrollmentId);
 }

--- a/src/main/java/com/foodmate/backend/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/EnrollmentServiceImpl.java
@@ -80,5 +80,30 @@ public class EnrollmentServiceImpl implements EnrollmentService {
         } else {
             throw new EnrollmentException(Error.REQUEST_NOT_FOUND);
         }
+
+
+    }
+
+    @Override
+    public String acceptEnrollment(Long enrollmentId) {
+
+        Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
+                .orElseThrow(() -> new EnrollmentException(Error.ENROLLMENT_NOT_FOUND));
+        enrollment.updateEnrollment(EnrollmentStatus.ACCEPT);
+        enrollment.updateDecisionDate(LocalDateTime.now());
+        enrollmentRepository.save(enrollment);
+
+        return "수락 완료";
+    }
+
+    @Override
+    public String refuseEnrollment(Long enrollmentId) {
+
+        Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
+                .orElseThrow(() -> new EnrollmentException(Error.ENROLLMENT_NOT_FOUND));
+        enrollment.updateEnrollment(EnrollmentStatus.REFUSE);
+        enrollmentRepository.save(enrollment);
+        return "거절 완료";
     }
 }
+

--- a/src/main/java/com/foodmate/backend/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/EnrollmentServiceImpl.java
@@ -90,7 +90,6 @@ public class EnrollmentServiceImpl implements EnrollmentService {
         Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
                 .orElseThrow(() -> new EnrollmentException(Error.ENROLLMENT_NOT_FOUND));
         enrollment.updateEnrollment(EnrollmentStatus.ACCEPT);
-        enrollment.updateDecisionDate(LocalDateTime.now());
         enrollmentRepository.save(enrollment);
 
         return "수락 완료";
@@ -103,6 +102,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
                 .orElseThrow(() -> new EnrollmentException(Error.ENROLLMENT_NOT_FOUND));
         enrollment.updateEnrollment(EnrollmentStatus.REFUSE);
         enrollmentRepository.save(enrollment);
+
         return "거절 완료";
     }
 }


### PR DESCRIPTION
##  Feature

- 신청 API - 모임 요청에 대한 수락 or 거절 처리 기능 추가했습니다.

- 모임 요청 수락 시
  - 상태(status = ACCEPT) 변경
  - 처리일자(decision_date= 현재시간) 등록
- 모임 요청 거절 시
  - 상태(status = REFUSE) 변경
  - 처리일자(decision_date = 현재시간) 등록

## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.
- 수락 완료
![image](https://github.com/withfoodmate/backend/assets/66156319/3ffc8bbe-d978-4c97-84c9-81a781315b99)

- 거절 완료
![image](https://github.com/withfoodmate/backend/assets/66156319/7f1e113c-b181-4b5e-87ad-2d0894414537)

- DB 확인
![image](https://github.com/withfoodmate/backend/assets/66156319/0d62bd13-7312-4658-91da-c989e609ae07)
