### PR TITLE
그룹 API - 날짜별 조회 기능 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/GroupController.java
+++ b/src/main/java/com/foodmate/backend/controller/GroupController.java
@@ -4,15 +4,19 @@ import com.foodmate.backend.dto.CommentDto;
 import com.foodmate.backend.dto.GroupDto;
 import com.foodmate.backend.dto.ReplyDto;
 import com.foodmate.backend.dto.SearchedGroupDto;
+import com.foodmate.backend.enums.Error;
+import com.foodmate.backend.exception.GroupException;
 import com.foodmate.backend.service.GroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -140,6 +144,21 @@ public class GroupController {
                                                                    @RequestParam String longitude,
                                                                    Pageable pageable) {
         return ResponseEntity.ok(groupService.searchByLocation(latitude, longitude, pageable));
+    }
+
+    // 날짜별 조회
+    @GetMapping("/search/date")
+    public ResponseEntity<Page<SearchedGroupDto>> searchByDate(@RequestParam
+                                                               @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
+                                                               @RequestParam
+                                                               @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end,
+                                                               Pageable pageable) {
+
+        if (start.isBefore(LocalDate.now()) || end.isBefore(start)) {
+            throw new GroupException(Error.INVALID_DATE_RANGE);
+        }
+
+        return ResponseEntity.ok(groupService.searchByDate(start, end, pageable));
     }
 
 }

--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -27,6 +27,7 @@ public enum Error {
     GROUP_DELETED("해당 모임은 삭제되었습니다.", HttpStatus.GONE),
     NO_MODIFY_PERMISSION_GROUP("해당 모임을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN),
     NO_DELETE_PERMISSION_GROUP("해당 모임을 삭제할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    INVALID_DATE_RANGE("검색 시작일 혹은 종료일 정보가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // ChatException
     CHATROOM_NOT_FOUND("해당 모임 아이디의 채팅룸은 존재하지 않습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
@@ -87,4 +87,19 @@ public interface FoodGroupRepository extends JpaRepository<FoodGroup, Long> {
             "ORDER BY FUNCTION('ST_DISTANCE', fg.location, :userLocation)")
     Page<SearchedGroupDto> searchByLocation(Point userLocation, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
+    // GroupServiceImpl - 날짜별 조회
+    @Query("SELECT new com.foodmate.backend.dto.SearchedGroupDto(" +
+            "fg.id, fg.title, fg.name, fg.groupDateTime, fg.maximum, fg.storeName, fg.storeAddress, fg.createdDate, " +
+            "m.id, m.nickname, m.image, f.type, COUNT(e.id)) " +
+            "FROM FoodGroup fg " +
+            "JOIN Member m ON fg.member.id = m.id " +
+            "JOIN Food f ON fg.food.id = f.id " +
+            "LEFT JOIN Enrollment e ON fg.id = e.foodGroup.id AND e.status = 'ACCEPT' " +
+            "WHERE fg.groupDateTime BETWEEN :start AND :end " +
+            "AND fg.isDeleted IS NULL " +
+            "GROUP BY fg.id, fg.title, fg.name, fg.groupDateTime, fg.maximum, fg.storeName, fg.storeAddress, fg.createdDate, " +
+            "m.id, m.nickname, m.image, f.type " +
+            "ORDER BY fg.groupDateTime ASC")
+    Page<SearchedGroupDto> searchByDate(LocalDateTime start, LocalDateTime end, Pageable pageable);
+
 }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 
+import java.time.LocalDate;
+
 public interface GroupService {
 
     String addGroup(Authentication authentication, GroupDto.Request request);
@@ -41,5 +43,7 @@ public interface GroupService {
     Page<SearchedGroupDto> getAllGroupList(Pageable pageable);
 
     Page<SearchedGroupDto> searchByLocation(String latitude, String longitude, Pageable pageable);
+
+    Page<SearchedGroupDto> searchByDate(LocalDate start, LocalDate end, Pageable pageable);
 
 }

--- a/src/main/java/com/foodmate/backend/service/impl/GroupServiceImpl.java
+++ b/src/main/java/com/foodmate/backend/service/impl/GroupServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -372,6 +373,17 @@ public class GroupServiceImpl implements GroupService {
         return foodGroupRepository.searchByLocation(userLocation,
                 LocalDateTime.now().plusMinutes(SEARCH_INTERVAL_MINUTE),
                 LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH), pageable);
+    }
+
+    // 날짜별 조회
+    @Override
+    public Page<SearchedGroupDto> searchByDate(LocalDate start, LocalDate end, Pageable pageable) {
+
+        LocalDateTime searchStart = (start.isEqual(LocalDate.now())) ?
+                LocalDateTime.now().plusMinutes(SEARCH_INTERVAL_MINUTE) : start.atStartOfDay();
+        LocalDateTime searchEnd = end.atTime(LocalTime.MAX);
+
+        return foodGroupRepository.searchByDate(searchStart, searchEnd, pageable);
     }
 
     // {groupId} 경로 검증 - 존재하는 그룹이면서, 삭제되지 않은 경우만 반환


### PR DESCRIPTION
##  Feature

- 그룹 API - 날짜별 조회 기능 추가하였습니다.
( GroupController, GroupService, GroupServiceImpl )

- 날짜별 조회를 위한 쿼리를 FoodGroupRepository 에 작성하였습니다. (정렬은 모임날짜 기준 오름차순)

- 페이징 처리하였습니다.

- 모임 날짜별 조회 기능 추가에 필요한 Error 이넘 작성하였습니다.

## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.

![image](https://github.com/withfoodmate/backend/assets/129507835/a34f9841-9ee7-4dc9-a868-72a5ca7d7fdc)


