### PR TITLE
그룹 API - 내 근처 모임(거리순) 조회 기능 쿼리 수정

### DIFF
--- a/src/main/java/com/foodmate/backend/enums/Error.java
+++ b/src/main/java/com/foodmate/backend/enums/Error.java
@@ -27,6 +27,7 @@ public enum Error {
     GROUP_DELETED("해당 모임은 삭제되었습니다.", HttpStatus.GONE),
     NO_MODIFY_PERMISSION_GROUP("해당 모임을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN),
     NO_DELETE_PERMISSION_GROUP("해당 모임을 삭제할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    INVALID_DATE_RANGE("검색 시작일 혹은 종료일 정보가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // ChatException
     CHATROOM_NOT_FOUND("해당 모임 아이디의 채팅룸은 존재하지 않습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
@@ -70,7 +70,6 @@ public interface FoodGroupRepository extends JpaRepository<FoodGroup, Long> {
             "ORDER BY fg.createdDate DESC")
     Page<SearchedGroupDto> getAllGroupList(LocalDateTime start, LocalDateTime end, Pageable pageable);
 
-    // TODO 5km 이내 필터링 조건 다시 알아보고 수정할 것
     // GroupServiceImpl - 거리순 조회 & 내 근처 모임
     @Query("SELECT new com.foodmate.backend.dto.SearchedGroupDto(" +
             "fg.id, fg.title, fg.name, fg.groupDateTime, fg.maximum, fg.storeName, fg.storeAddress, fg.createdDate, " +
@@ -81,10 +80,10 @@ public interface FoodGroupRepository extends JpaRepository<FoodGroup, Long> {
             "LEFT JOIN Enrollment e ON fg.id = e.foodGroup.id AND e.status = 'ACCEPT' " +
             "WHERE fg.groupDateTime BETWEEN :start AND :end " +
             "AND fg.isDeleted IS NULL " +
-            "AND FUNCTION('ST_DISTANCE', fg.location, :userLocation) < 5000 " +
+            "AND FUNCTION('ST_Distance_Sphere', fg.location, :userLocation) < 5000 " +
             "GROUP BY fg.id, fg.title, fg.name, fg.groupDateTime, fg.maximum, fg.storeName, fg.storeAddress, fg.createdDate, " +
             "m.id, m.nickname, m.image, f.type " +
-            "ORDER BY FUNCTION('ST_DISTANCE', fg.location, :userLocation)")
+            "ORDER BY FUNCTION('ST_Distance_Sphere', fg.location, :userLocation)")
     Page<SearchedGroupDto> searchByLocation(Point userLocation, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
     // GroupServiceImpl - 날짜별 조회


### PR DESCRIPTION
##  Feature

- 그룹 API - 내 근처 모임(거리순) 조회 기능 쿼리 수정하였습니다.

- 모임 날짜별 조회 기능에 필요한 Error 이넘 작성하였습니다.

## Test

- [ ] 테스트 코드
- [x] API 테스트

- API 명세서와 동일한 응답 내려주는거 확인하였습니다.

- 반경 5km 이내 필터링 동작 확인 완료

![image](https://github.com/withfoodmate/backend/assets/129507835/cef7f147-3998-46ef-8cd2-abd750ec454d)


