### PR TITLE
랭킹 API & 그룹 API 리팩토링 2차

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/GroupController.java
+++ b/src/main/java/com/foodmate/backend/controller/GroupController.java
@@ -28,8 +28,8 @@ public class GroupController {
 
     // 모임 생성
     @PostMapping
-    public ResponseEntity<?> addGroup(Authentication authentication,
-                                      @RequestBody @Valid GroupDto.Request request) {
+    public ResponseEntity<Void> addGroup(Authentication authentication,
+                                         @RequestBody @Valid GroupDto.Request request) {
         groupService.addGroup(authentication, request);
         return ResponseEntity.ok().build();
     }
@@ -42,84 +42,84 @@ public class GroupController {
 
     // 특정 모임 수정
     @PutMapping("/{groupId}")
-    public ResponseEntity<?> updateGroup(@PathVariable Long groupId,
-                                         Authentication authentication,
-                                         @RequestBody @Valid GroupDto.Request request) {
+    public ResponseEntity<Void> updateGroup(@PathVariable Long groupId,
+                                            Authentication authentication,
+                                            @RequestBody @Valid GroupDto.Request request) {
         groupService.updateGroup(groupId, authentication, request);
         return ResponseEntity.ok().build();
     }
 
     // 특정 모임 삭제
     @DeleteMapping("/{groupId}")
-    public ResponseEntity<?> deleteGroup(@PathVariable Long groupId,
-                                         Authentication authentication) {
+    public ResponseEntity<Void> deleteGroup(@PathVariable Long groupId,
+                                            Authentication authentication) {
         groupService.deleteGroup(groupId, authentication);
         return ResponseEntity.ok().build();
     }
 
     // 특정 모임 신청
     @PostMapping("/{groupId}/enrollment")
-    public ResponseEntity<?> enrollInGroup(@PathVariable Long groupId,
-                                           Authentication authentication) {
+    public ResponseEntity<Void> enrollInGroup(@PathVariable Long groupId,
+                                              Authentication authentication) {
         groupService.enrollInGroup(groupId, authentication);
         return ResponseEntity.ok().build();
     }
 
     // 댓글 작성
     @PostMapping("/{groupId}/comment")
-    public ResponseEntity<?> addComment(@PathVariable Long groupId,
-                                        Authentication authentication,
-                                        @RequestBody @Valid CommentDto.Request request) {
+    public ResponseEntity<Void> addComment(@PathVariable Long groupId,
+                                           Authentication authentication,
+                                           @RequestBody @Valid CommentDto.Request request) {
         groupService.addComment(groupId, authentication, request);
         return ResponseEntity.ok().build();
     }
 
     // 대댓글 작성
     @PostMapping("/{groupId}/comment/{commentId}/reply")
-    public ResponseEntity<?> addReply(@PathVariable Long groupId,
-                                      @PathVariable Long commentId,
-                                      Authentication authentication,
-                                      @RequestBody @Valid ReplyDto.Request request) {
+    public ResponseEntity<Void> addReply(@PathVariable Long groupId,
+                                         @PathVariable Long commentId,
+                                         Authentication authentication,
+                                         @RequestBody @Valid ReplyDto.Request request) {
         groupService.addReply(groupId, commentId, authentication, request);
         return ResponseEntity.ok().build();
     }
 
     // 댓글 수정
     @PutMapping("/{groupId}/comment/{commentId}")
-    public ResponseEntity<?> updateComment(@PathVariable Long groupId,
-                                           @PathVariable Long commentId,
-                                           Authentication authentication,
-                                           @RequestBody @Valid CommentDto.Request request) {
+    public ResponseEntity<Void> updateComment(@PathVariable Long groupId,
+                                              @PathVariable Long commentId,
+                                              Authentication authentication,
+                                              @RequestBody @Valid CommentDto.Request request) {
         groupService.updateComment(groupId, commentId, authentication, request);
         return ResponseEntity.ok().build();
     }
 
     // 대댓글 수정
     @PutMapping("/{groupId}/comment/{commentId}/reply/{replyId}")
-    public ResponseEntity<?> updateReply(@PathVariable Long groupId,
-                                         @PathVariable Long commentId,
-                                         @PathVariable Long replyId,
-                                         Authentication authentication,
-                                         @RequestBody @Valid ReplyDto.Request request) {
+    public ResponseEntity<Void> updateReply(@PathVariable Long groupId,
+                                            @PathVariable Long commentId,
+                                            @PathVariable Long replyId,
+                                            Authentication authentication,
+                                            @RequestBody @Valid ReplyDto.Request request) {
         groupService.updateReply(groupId, commentId, replyId, authentication, request);
         return ResponseEntity.ok().build();
     }
 
     // 댓글 삭제
     @DeleteMapping("/{groupId}/comment/{commentId}")
-    public ResponseEntity<?> deleteComment(@PathVariable Long groupId,
-                                           @PathVariable Long commentId,
-                                           Authentication authentication) {
+    public ResponseEntity<Void> deleteComment(@PathVariable Long groupId,
+                                              @PathVariable Long commentId,
+                                              Authentication authentication) {
         groupService.deleteComment(groupId, commentId, authentication);
         return ResponseEntity.ok().build();
     }
 
     // 대댓글 삭제
     @DeleteMapping("/{groupId}/comment/{commentId}/reply/{replyId}")
-    public ResponseEntity<?> deleteReply(@PathVariable Long groupId,
-                                         @PathVariable Long commentId,
-                                         @PathVariable Long replyId,
-                                         Authentication authentication) {
+    public ResponseEntity<Void> deleteReply(@PathVariable Long groupId,
+                                            @PathVariable Long commentId,
+                                            @PathVariable Long replyId,
+                                            Authentication authentication) {
         groupService.deleteReply(groupId, commentId, replyId, authentication);
         return ResponseEntity.ok().build();
     }
@@ -149,7 +149,7 @@ public class GroupController {
         return ResponseEntity.ok(groupService.getAllGroupList(pageable));
     }
 
-    // 거리순 조회 & 내 근처 모임
+    // 거리순 조회
     @GetMapping("/search/distance")
     public ResponseEntity<Page<SearchedGroupDto>> searchByLocation(@RequestParam String latitude,
                                                                    @RequestParam String longitude,
@@ -177,6 +177,14 @@ public class GroupController {
     public ResponseEntity<Page<SearchedGroupDto>> searchByFood(@RequestParam List<String> foods,
                                                                Pageable pageable) {
         return ResponseEntity.ok(groupService.searchByFood(foods, pageable));
+    }
+
+    // 내 근처 모임
+    @GetMapping("/near")
+    public ResponseEntity<Page<SearchedGroupDto>> getNearbyGroupList(@RequestParam String latitude,
+                                                                     @RequestParam String longitude,
+                                                                     Pageable pageable) {
+        return ResponseEntity.ok(groupService.getNearbyGroupList(latitude, longitude, pageable));
     }
 
     // 로그인한 사용자가 참여한 모임 조회

--- a/src/main/java/com/foodmate/backend/controller/RankingController.java
+++ b/src/main/java/com/foodmate/backend/controller/RankingController.java
@@ -19,26 +19,26 @@ public class RankingController {
 
     // 좋아요 랭킹
     @GetMapping("/likes")
-    public ResponseEntity<List<RankingDto.Likes>> showLikesRanking() {
-        return ResponseEntity.ok(rankingService.showLikesRanking());
+    public ResponseEntity<List<RankingDto.Likes>> getLikesRanking() {
+        return ResponseEntity.ok(rankingService.getLikesRanking());
     }
 
     // 모임왕 랭킹
     @GetMapping("/meeting")
-    public ResponseEntity<List<RankingDto.Meeting>> showMeetingRanking() {
-        return ResponseEntity.ok(rankingService.showMeetingRanking());
+    public ResponseEntity<List<RankingDto.Meeting>> getMeetingRanking() {
+        return ResponseEntity.ok(rankingService.getMeetingRanking());
     }
 
     // 많이찾는 식당 랭킹
     @GetMapping("/store")
-    public ResponseEntity<List<RankingDto.Store>> showStoreRanking() {
-        return ResponseEntity.ok(rankingService.showStoreRanking());
+    public ResponseEntity<List<RankingDto.Store>> getStoreRanking() {
+        return ResponseEntity.ok(rankingService.getStoreRanking());
     }
 
     // 음식 카테고리 랭킹
     @GetMapping("/food")
-    public ResponseEntity<List<RankingDto.Food>> showFoodRanking() {
-        return ResponseEntity.ok(rankingService.showFoodRanking());
+    public ResponseEntity<List<RankingDto.Food>> getFoodRanking() {
+        return ResponseEntity.ok(rankingService.getFoodRanking());
     }
 
 }

--- a/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
@@ -52,12 +52,11 @@ public interface FoodGroupRepository extends JpaRepository<FoodGroup, Long> {
                 start, end, pageable).map(foodGroup -> new SearchedGroupDto(foodGroup));
     }
 
-    // GroupService - 거리순 조회 & 내 근처 모임
+    // GroupService - 거리순 조회
     @Query("SELECT new com.foodmate.backend.dto.SearchedGroupDto(fg) " +
             "FROM FoodGroup fg " +
             "WHERE fg.groupDateTime BETWEEN :start AND :end " +
             "AND fg.isDeleted IS NULL " +
-            "AND FUNCTION('ST_Distance_Sphere', fg.location, :userLocation) < 5000 " +
             "ORDER BY FUNCTION('ST_Distance_Sphere', fg.location, :userLocation)")
     Page<SearchedGroupDto> searchByLocation(Point userLocation, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
@@ -70,5 +69,14 @@ public interface FoodGroupRepository extends JpaRepository<FoodGroup, Long> {
             "AND fg.isDeleted IS NULL " +
             "ORDER BY fg.createdDate DESC")
     Page<SearchedGroupDto> searchByFood(List<String> foodTypes, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    // GroupService - 내 근처 모임
+    @Query("SELECT new com.foodmate.backend.dto.SearchedGroupDto(fg) " +
+            "FROM FoodGroup fg " +
+            "WHERE fg.groupDateTime BETWEEN :start AND :end " +
+            "AND fg.isDeleted IS NULL " +
+            "AND FUNCTION('ST_Distance_Sphere', fg.location, :userLocation) < 5000 " +
+            "ORDER BY FUNCTION('ST_Distance_Sphere', fg.location, :userLocation)")
+    Page<SearchedGroupDto> getNearbyGroupList(Point userLocation, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
 }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -327,7 +327,7 @@ public class GroupService {
                 LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH), pageable);
     }
 
-    // 거리순 조회 & 내 근처 모임
+    // 거리순 조회
     public Page<SearchedGroupDto> searchByLocation(String latitude, String longitude, Pageable pageable) {
 
         Point userLocation = getPoint(latitude, longitude);
@@ -358,6 +358,16 @@ public class GroupService {
         }
 
         return foodGroupRepository.searchByFood(foods,
+                LocalDateTime.now().plusMinutes(SEARCH_INTERVAL_MINUTE),
+                LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH), pageable);
+    }
+
+    // 내 근처 모임
+    public Page<SearchedGroupDto> getNearbyGroupList(String latitude, String longitude, Pageable pageable) {
+
+        Point userLocation = getPoint(latitude, longitude);
+
+        return foodGroupRepository.getNearbyGroupList(userLocation,
                 LocalDateTime.now().plusMinutes(SEARCH_INTERVAL_MINUTE),
                 LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH), pageable);
     }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -307,9 +307,11 @@ public class GroupService {
     // 검색 기능
     public Page<SearchedGroupDto> searchByKeyword(String keyword, Pageable pageable) {
 
+        LocalDateTime current = LocalDateTime.now();
+
         return foodGroupRepository.searchByKeyword(keyword,
-                LocalDateTime.now().plusMinutes(SEARCH_INTERVAL_MINUTE),
-                LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH), pageable);
+                current.plusMinutes(SEARCH_INTERVAL_MINUTE),
+                current.plusMonths(RESERVATION_RANGE_MONTH), pageable);
     }
 
     // 오늘 모임 조회
@@ -322,9 +324,11 @@ public class GroupService {
     // 전체 모임 조회
     public Page<SearchedGroupDto> getAllGroupList(Pageable pageable) {
 
+        LocalDateTime current = LocalDateTime.now();
+
         return foodGroupRepository.getAllGroupList(
-                LocalDateTime.now().plusMinutes(SEARCH_INTERVAL_MINUTE),
-                LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH), pageable);
+                current.plusMinutes(SEARCH_INTERVAL_MINUTE),
+                current.plusMonths(RESERVATION_RANGE_MONTH), pageable);
     }
 
     // 거리순 조회
@@ -332,9 +336,11 @@ public class GroupService {
 
         Point userLocation = getPoint(latitude, longitude);
 
+        LocalDateTime current = LocalDateTime.now();
+
         return foodGroupRepository.searchByLocation(userLocation,
-                LocalDateTime.now().plusMinutes(SEARCH_INTERVAL_MINUTE),
-                LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH), pageable);
+                current.plusMinutes(SEARCH_INTERVAL_MINUTE),
+                current.plusMonths(RESERVATION_RANGE_MONTH), pageable);
     }
 
     // 날짜별 조회
@@ -357,9 +363,11 @@ public class GroupService {
             }
         }
 
+        LocalDateTime current = LocalDateTime.now();
+
         return foodGroupRepository.searchByFood(foods,
-                LocalDateTime.now().plusMinutes(SEARCH_INTERVAL_MINUTE),
-                LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH), pageable);
+                current.plusMinutes(SEARCH_INTERVAL_MINUTE),
+                current.plusMonths(RESERVATION_RANGE_MONTH), pageable);
     }
 
     // 내 근처 모임
@@ -367,9 +375,11 @@ public class GroupService {
 
         Point userLocation = getPoint(latitude, longitude);
 
+        LocalDateTime current = LocalDateTime.now();
+
         return foodGroupRepository.getNearbyGroupList(userLocation,
-                LocalDateTime.now().plusMinutes(SEARCH_INTERVAL_MINUTE),
-                LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH), pageable);
+                current.plusMinutes(SEARCH_INTERVAL_MINUTE),
+                current.plusMonths(RESERVATION_RANGE_MONTH), pageable);
     }
 
     // 로그인한 사용자가 참여한 모임 조회
@@ -377,10 +387,12 @@ public class GroupService {
 
         Member member = getMember(authentication);
 
+        LocalDateTime current = LocalDateTime.now();
+
         return new GroupDto.AcceptedGroup(enrollmentRepository.getAcceptedGroupIdList(
                 member.getId(),
-                LocalDateTime.now().plusMinutes(SEARCH_INTERVAL_MINUTE),
-                LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH)));
+                current.plusMinutes(SEARCH_INTERVAL_MINUTE),
+                current.plusMonths(RESERVATION_RANGE_MONTH)));
     }
 
     // {groupId} 경로 검증 - 존재하는 그룹이면서, 삭제되지 않은 경우만 반환
@@ -437,9 +449,11 @@ public class GroupService {
         // 입력된 모임일시
         LocalDateTime groupDateTime = request.getDate().atTime(request.getTime());
 
+        LocalDateTime current = LocalDateTime.now();
+
         // 현재시간으로부터 한시간 이후 ~ 한달 이내의 모임만 생성 가능
-        if (groupDateTime.isBefore(LocalDateTime.now().plusHours(RESERVATION_INTERVAL_HOUR)) ||
-                groupDateTime.isAfter(LocalDateTime.now().plusMonths(RESERVATION_RANGE_MONTH))) {
+        if (groupDateTime.isBefore(current.plusHours(RESERVATION_INTERVAL_HOUR)) ||
+                groupDateTime.isAfter(current.plusMonths(RESERVATION_RANGE_MONTH))) {
             throw new GroupException(Error.OUT_OF_DATE_RANGE);
         }
 

--- a/src/main/java/com/foodmate/backend/service/RankingService.java
+++ b/src/main/java/com/foodmate/backend/service/RankingService.java
@@ -22,7 +22,7 @@ public class RankingService {
     private final FoodRepository foodRepository;
 
     // 좋아요 랭킹
-    public List<RankingDto.Likes> showLikesRanking() {
+    public List<RankingDto.Likes> getLikesRanking() {
 
         List<RankingDto.Likes> result = new ArrayList<>();
 
@@ -41,7 +41,7 @@ public class RankingService {
     }
 
     // 모임왕 랭킹
-    public List<RankingDto.Meeting> showMeetingRanking() {
+    public List<RankingDto.Meeting> getMeetingRanking() {
 
         List<RankingDto.Meeting> result = new ArrayList<>();
 
@@ -61,7 +61,7 @@ public class RankingService {
     }
 
     // 많이찾는 식당 랭킹
-    public List<RankingDto.Store> showStoreRanking() {
+    public List<RankingDto.Store> getStoreRanking() {
 
         List<RankingDto.Store> result = new ArrayList<>();
 
@@ -80,7 +80,7 @@ public class RankingService {
     }
 
     // 음식 카테고리 랭킹
-    public List<RankingDto.Food> showFoodRanking() {
+    public List<RankingDto.Food> getFoodRanking() {
 
         List<RankingDto.Food> result = new ArrayList<>();
 


### PR DESCRIPTION
##  Feature

- 랭킹 API 메소드명을 변경하였습니다. ( show -> get )

- 그룹 API 응답 형식을 수정하였습니다. ( 와일드 카드 -> Void )

- 프론트의 요청으로 그룹 API 중 거리순 조회와 내 근처 모임 API 를 분리하였습니다.

## Test

- [ ] 테스트 코드
- [x] API 테스트

- 이전과 동일하게 작동하는 것 확인하였습니다.