### PR TITLE
그룹 API 리팩토링 ( DTO , 내 근처 모임 API 관련 )

### DIFF
--- a/src/main/java/com/foodmate/backend/controller/GroupController.java
+++ b/src/main/java/com/foodmate/backend/controller/GroupController.java
@@ -1,9 +1,6 @@
 package com.foodmate.backend.controller;
 
-import com.foodmate.backend.dto.CommentDto;
-import com.foodmate.backend.dto.GroupDto;
-import com.foodmate.backend.dto.ReplyDto;
-import com.foodmate.backend.dto.SearchedGroupDto;
+import com.foodmate.backend.dto.*;
 import com.foodmate.backend.enums.Error;
 import com.foodmate.backend.exception.GroupException;
 import com.foodmate.backend.service.GroupService;
@@ -181,9 +178,9 @@ public class GroupController {
 
     // 내 근처 모임
     @GetMapping("/near")
-    public ResponseEntity<Page<SearchedGroupDto>> getNearbyGroupList(@RequestParam String latitude,
-                                                                     @RequestParam String longitude,
-                                                                     Pageable pageable) {
+    public ResponseEntity<Page<NearbyGroupDto>> getNearbyGroupList(@RequestParam String latitude,
+                                                                   @RequestParam String longitude,
+                                                                   Pageable pageable) {
         return ResponseEntity.ok(groupService.getNearbyGroupList(latitude, longitude, pageable));
     }
 

--- a/src/main/java/com/foodmate/backend/dto/CommentDto.java
+++ b/src/main/java/com/foodmate/backend/dto/CommentDto.java
@@ -36,7 +36,7 @@ public class CommentDto {
         private LocalDateTime updatedDate;
         private List<ReplyDto.Response> replies;
 
-        public static Response fromEntity(Comment comment, List<ReplyDto.Response> replies) {
+        public static Response createCommentResponse(Comment comment, List<ReplyDto.Response> replies) {
             return Response.builder()
                     .commentId(comment.getId())
                     .memberId(comment.getMember().getId())

--- a/src/main/java/com/foodmate/backend/dto/GroupDto.java
+++ b/src/main/java/com/foodmate/backend/dto/GroupDto.java
@@ -62,7 +62,7 @@ public class GroupDto {
         private LocalDateTime createdDate;
         private Long chatRoomId;
 
-        public static DetailResponse fromEntity(FoodGroup foodGroup, ChatRoom chatRoom) {
+        public static DetailResponse createGroupDetailResponse(FoodGroup foodGroup, ChatRoom chatRoom) {
             return DetailResponse.builder()
                     .groupId(foodGroup.getId())
                     .memberId(foodGroup.getMember().getId())

--- a/src/main/java/com/foodmate/backend/dto/NearbyGroupDto.java
+++ b/src/main/java/com/foodmate/backend/dto/NearbyGroupDto.java
@@ -1,0 +1,53 @@
+package com.foodmate.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.foodmate.backend.entity.FoodGroup;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+public class NearbyGroupDto {
+
+    private Long groupId;
+    private Long memberId;
+    private String nickname;
+    private String image;
+    private String title;
+    private String name;
+    private String food;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+    @JsonFormat(pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime time;
+    private int maximum;
+    private int current;
+    private String storeName;
+    private String storeAddress;
+    private String latitude;
+    private String longitude;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+    private LocalDateTime createdDate;
+
+    public NearbyGroupDto(FoodGroup foodGroup) {
+        this.groupId = foodGroup.getId();
+        this.memberId = foodGroup.getMember().getId();
+        this.nickname = foodGroup.getMember().getNickname();
+        this.image = foodGroup.getMember().getImage();
+        this.title = foodGroup.getTitle();
+        this.name = foodGroup.getName();
+        this.food = foodGroup.getFood().getType();
+        this.date = foodGroup.getGroupDateTime().toLocalDate();
+        this.time = foodGroup.getGroupDateTime().toLocalTime();
+        this.maximum = foodGroup.getMaximum();
+        this.current = foodGroup.getAttendance();
+        this.storeName = foodGroup.getStoreName();
+        this.storeAddress = foodGroup.getStoreAddress();
+        this.latitude = String.valueOf(foodGroup.getLocation().getY());
+        this.longitude = String.valueOf(foodGroup.getLocation().getX());
+        this.createdDate = foodGroup.getCreatedDate();
+    }
+
+}

--- a/src/main/java/com/foodmate/backend/dto/ReplyDto.java
+++ b/src/main/java/com/foodmate/backend/dto/ReplyDto.java
@@ -34,7 +34,7 @@ public class ReplyDto {
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         private LocalDateTime updatedDate;
 
-        public static Response fromEntity(Reply reply) {
+        public static Response createReplyResponse(Reply reply) {
             return Response.builder()
                     .replyId(reply.getId())
                     .memberId(reply.getMember().getId())

--- a/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
@@ -39,7 +39,7 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
             "ORDER BY e.enrollDate ASC")
     Page<Enrollment> findByMyEnrollmentProcessedListWithStatus(@Param("id") Long readerId, @Param("status") EnrollmentStatus status, Pageable pageable);
 
-    // 로그인한 사용자가 참여한 모임 조회 ver. 1
+    // 로그인한 사용자가 참여한 모임 조회
     List<Enrollment> findAllByMemberAndStatusAndFoodGroupGroupDateTimeBetween(
             Member member, EnrollmentStatus status, LocalDateTime start, LocalDateTime end);
 
@@ -47,14 +47,6 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
         return findAllByMemberAndStatusAndFoodGroupGroupDateTimeBetween(member, status, start, end).stream().map(
                 Enrollment -> Enrollment.getFoodGroup().getId()).collect(Collectors.toList());
     }
-
-    // 로그인한 사용자가 참여한 모임 조회 ver. 2
-    @Query("SELECT e.foodGroup.id " +
-            "FROM Enrollment e " +
-            "WHERE e.member.id = :memberId " +
-            "AND e.status = 'ACCEPT' " +
-            "AND e.foodGroup.groupDateTime BETWEEN :startDateTime AND :endDateTime")
-    List<Long> getAcceptedGroupIdList(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
     // WebSocketChannelInterceptor 에서 모임참여자 검증
     boolean existsByMemberIdAndFoodGroupAndStatus(Long memberId, FoodGroup foodGroup, EnrollmentStatus status);

--- a/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
@@ -1,5 +1,6 @@
 package com.foodmate.backend.repository;
 
+import com.foodmate.backend.dto.NearbyGroupDto;
 import com.foodmate.backend.dto.SearchedGroupDto;
 import com.foodmate.backend.entity.FoodGroup;
 import org.locationtech.jts.geom.Point;
@@ -71,12 +72,12 @@ public interface FoodGroupRepository extends JpaRepository<FoodGroup, Long> {
     Page<SearchedGroupDto> searchByFood(List<String> foodTypes, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
     // GroupService - 내 근처 모임
-    @Query("SELECT new com.foodmate.backend.dto.SearchedGroupDto(fg) " +
+    @Query("SELECT new com.foodmate.backend.dto.NearbyGroupDto(fg) " +
             "FROM FoodGroup fg " +
             "WHERE fg.groupDateTime BETWEEN :start AND :end " +
             "AND fg.isDeleted IS NULL " +
             "AND FUNCTION('ST_Distance_Sphere', fg.location, :userLocation) < 5000 " +
             "ORDER BY FUNCTION('ST_Distance_Sphere', fg.location, :userLocation)")
-    Page<SearchedGroupDto> getNearbyGroupList(Point userLocation, LocalDateTime start, LocalDateTime end, Pageable pageable);
+    Page<NearbyGroupDto> getNearbyGroupList(Point userLocation, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
 }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -1,9 +1,6 @@
 package com.foodmate.backend.service;
 
-import com.foodmate.backend.dto.CommentDto;
-import com.foodmate.backend.dto.GroupDto;
-import com.foodmate.backend.dto.ReplyDto;
-import com.foodmate.backend.dto.SearchedGroupDto;
+import com.foodmate.backend.dto.*;
 import com.foodmate.backend.entity.*;
 import com.foodmate.backend.enums.EnrollmentStatus;
 import com.foodmate.backend.enums.Error;
@@ -72,7 +69,7 @@ public class GroupService {
         // 모임 저장
         foodGroupRepository.save(foodGroup);
 
-        // TODO 채팅룸 생성 - 그룹 채팅 기능 구현 후 보완할 것
+        // 채팅방 생성
         chatRoomRepository.save(new ChatRoom(foodGroup));
     }
 
@@ -84,7 +81,7 @@ public class GroupService {
         ChatRoom chatRoom = chatRoomRepository.findByFoodGroupId(groupId)
                 .orElseThrow(() -> new ChatException(Error.CHATROOM_NOT_FOUND));
 
-        return GroupDto.DetailResponse.fromEntity(group, chatRoom);
+        return GroupDto.DetailResponse.createGroupDetailResponse(group, chatRoom);
     }
 
     // 특정 모임 수정
@@ -294,11 +291,11 @@ public class GroupService {
 
             // 대댓글 DTO 로 변환 & 리스트에 추가
             for (Reply reply : replies) {
-                replyDTOs.add(ReplyDto.Response.fromEntity(reply));
+                replyDTOs.add(ReplyDto.Response.createReplyResponse(reply));
             }
 
             // 댓글 DTO 로 변환 (안에 대댓글 리스트 세팅)
-            return CommentDto.Response.fromEntity(comment, replyDTOs);
+            return CommentDto.Response.createCommentResponse(comment, replyDTOs);
         });
 
         return commentDTOs;
@@ -371,7 +368,7 @@ public class GroupService {
     }
 
     // 내 근처 모임
-    public Page<SearchedGroupDto> getNearbyGroupList(String latitude, String longitude, Pageable pageable) {
+    public Page<NearbyGroupDto> getNearbyGroupList(String latitude, String longitude, Pageable pageable) {
 
         Point userLocation = getPoint(latitude, longitude);
 
@@ -389,8 +386,9 @@ public class GroupService {
 
         LocalDateTime current = LocalDateTime.now();
 
-        return new GroupDto.AcceptedGroup(enrollmentRepository.getAcceptedGroupIdList(
-                member.getId(),
+        return new GroupDto.AcceptedGroup(enrollmentRepository.getAcceptedGroupList(
+                member,
+                EnrollmentStatus.ACCEPT,
                 current.plusMinutes(SEARCH_INTERVAL_MINUTE),
                 current.plusMonths(RESERVATION_RANGE_MONTH)));
     }


### PR DESCRIPTION
##  Feature

- 프로젝트의 통일성을 위하여 DTO 생성 메소드명을 변경하였습니다. (GroupDto, CommentDto, ReplyDto)

- 프론트의 요청으로 내 근처 모임 API 의  새로운 DTO 를 생성하고, 기존 응답 형식을 변경하였습니다.
  (NearbyGroupDto, GroupController, FoodGroupRepository)
  
- 메소드명 변경과 응답 DTO 변경으로 인해 GroupService 코드를 수정하였습니다.
  
- EnrollmentRepository 의 불필요한 메소드를 삭제하였습니다.
  
## Test

- [ ] 테스트 코드
- [x] API 테스트

- 이전과 동일하게 작동하는 것 확인하였습니다.
- 내 근처 모임 API 도 명세서와 동일한 응답 내려주는 것 확인하였습니다.

![image](https://github.com/withfoodmate/backend/assets/129507835/2dd02f86-32c1-451f-ad27-247c42d2c810)

