### PR TITLE
채팅 API - 구독/구독취소 이벤트 발생시 ChatMember 추가/삭제

### DIFF
--- a/src/main/java/com/foodmate/backend/component/WebSocketEventListener.java
+++ b/src/main/java/com/foodmate/backend/component/WebSocketEventListener.java
@@ -42,7 +42,7 @@ public class WebSocketEventListener {
 
         String message = nickname + "님이 들어왔습니다.";
         sendingOperations.convertAndSend(destination, message);
-        chatMessageService.incrementAttendance(destination);
+        chatMessageService.incrementAttendance(destination, nickname);
     }
 
     // 채팅방 구독 취소
@@ -56,7 +56,7 @@ public class WebSocketEventListener {
 
         String message = nickname + "님이 나갔습니다.";
         sendingOperations.convertAndSend(destination, message);
-        chatMessageService.decrementAttendance(destination);
+        chatMessageService.decrementAttendance(destination, nickname);
     }
 
     // 연결 종료시

--- a/src/main/java/com/foodmate/backend/entity/ChatMember.java
+++ b/src/main/java/com/foodmate/backend/entity/ChatMember.java
@@ -4,10 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 @Builder
 @AllArgsConstructor
@@ -25,6 +28,7 @@ public class ChatMember {
     @ManyToOne
     private ChatRoom chatRoom;
 
+    @CreatedDate
     private LocalDateTime insertTime;
 
     private LocalDateTime lastReadTime;

--- a/src/main/java/com/foodmate/backend/repository/ChatMemberRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/ChatMemberRepository.java
@@ -14,4 +14,8 @@ public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
     List<ChatMember> findByMember(Member member);
 
     List<ChatMember> findByChatRoom(ChatRoom chatRoom);
+
+    // 해당 채팅방에서 해당 멤버 삭제
+    void deleteByMemberAndChatRoom(Member member, ChatRoom chatRoom);
+
 }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -137,9 +137,6 @@ public class GroupService {
 
         // 해당 모임에 신청한 모임신청목록들의 상태를 모임취소로 일괄 변경
         enrollmentRepository.changeStatusByGroupId(groupId, EnrollmentStatus.GROUP_CANCEL);
-
-        // TODO 채팅방 삭제 - 그룹 채팅 기능 구현 후 보완할 것
-        chatRoomRepository.deleteByFoodGroupId(groupId);
     }
 
     // 특정 모임 신청


### PR DESCRIPTION
##  Feature

- 채팅 API - 구독/구독취소 이벤트 발생시 ChatMember 추가/삭제 기능 추가하였습니다.
  ( WebSocketEventListener, ChatMessageService )

- ChatMember 엔티티에 필요한 어노테이션을 추가하였습니다.

- 기능 추가에 필요한 메소드를 ChatMemberRepository 에 작성하였습니다.

## Test

- [ ] 테스트 코드
- [x] APIC 사이트에서 테스트하였습니다.

![image](https://github.com/withfoodmate/backend/assets/129507835/9d8478a8-d6d9-4618-b603-24ff6680c131)


