### PR TITLE
채팅 API - ChatMember 중복 생성 방지 코드 추가

### DIFF
--- a/src/main/java/com/foodmate/backend/entity/ChatMember.java
+++ b/src/main/java/com/foodmate/backend/entity/ChatMember.java
@@ -1,9 +1,6 @@
 package com.foodmate.backend.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -15,6 +12,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Setter
 @Getter
 public class ChatMember {
 

--- a/src/main/java/com/foodmate/backend/repository/ChatMemberRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/ChatMemberRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
@@ -14,6 +15,8 @@ public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
     List<ChatMember> findByMember(Member member);
 
     List<ChatMember> findByChatRoom(ChatRoom chatRoom);
+
+    Optional<ChatMember> findByMemberAndChatRoom(Member member, ChatRoom chatRoom);
 
     // 해당 채팅방에서 해당 멤버 삭제
     void deleteByMemberAndChatRoom(Member member, ChatRoom chatRoom);

--- a/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
+++ b/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
@@ -357,7 +357,6 @@ public class GroupServiceTest {
     verify(foodGroupRepository, times(1)).save(mockGroup);
     verify(enrollmentRepository, times(1))
         .changeStatusByGroupId(groupId, EnrollmentStatus.GROUP_CANCEL);
-    verify(chatRoomRepository, times(1)).deleteByFoodGroupId(groupId);
 
   }
 


### PR DESCRIPTION
##  Feature

- 채팅 API - 같은 채팅방 구독 시, ChatMember 중복 생성 방지하는 코드를 추가하였습니다.
  ( ChatMessageService )

- ChatMember 엔티티에 필요한 어노테이션을 추가하였습니다.

- 기능 추가에 필요한 메소드를 ChatMemberRepository 에 작성하였습니다.

## Test

- [ ] 테스트 코드
- [x] APIC 사이트에서 테스트하였습니다.

- 이전과 동일하게 작동하며, ChatMember 중복 생성되지 않는 것 확인하였습니다.


