### PR TITLE
그룹 API - 테스트 코드 추가

### DIFF
--- a/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
+++ b/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
@@ -871,6 +871,28 @@ public class GroupServiceTest {
 
   }
 
+  @Test
+  @DisplayName("전체 모임 조회 성공")
+  void success_getAllGroupList() {
+
+    //given
+    Pageable pageable = PageRequest.of(pageNumber, pageSize);
+    List<SearchedGroupDto> entities = new ArrayList<>();
+    Page<SearchedGroupDto> page = new PageImpl<>(entities, pageable, entities.size());
+
+    given(foodGroupRepository.getAllGroupList(any(), any(), any())).willReturn(page);
+
+    //when
+    Page<SearchedGroupDto> response = groupService.getAllGroupList(pageable);
+
+    //then
+    verify(foodGroupRepository, times(1)).getAllGroupList(any(), any(), any());
+
+    assertNotNull(response);
+    assertEquals(entities.size(), response.getContent().size());
+
+  }
+
   private Authentication createAuthentication() {
 
     String email = "dlaehdgus23@naver.com";

--- a/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
+++ b/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
@@ -2,6 +2,7 @@ package com.foodmate.backend.service;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import com.foodmate.backend.dto.CommentDto;
 import com.foodmate.backend.dto.GroupDto;
 import com.foodmate.backend.dto.ReplyDto;
+import com.foodmate.backend.dto.SearchedGroupDto;
 import com.foodmate.backend.entity.ChatRoom;
 import com.foodmate.backend.entity.Comment;
 import com.foodmate.backend.entity.Food;
@@ -821,6 +823,29 @@ public class GroupServiceTest {
         () -> assertEquals(replyContent.getUpdatedDate(),
             responseReplyContent.getUpdatedDate())
     );
+
+  }
+
+  @Test
+  @DisplayName("검색 기능 성공")
+  void success_searchByKeyword() {
+
+    //given
+    Pageable pageable = PageRequest.of(pageNumber, pageSize);
+    List<SearchedGroupDto> entities = new ArrayList<>();
+    Page<SearchedGroupDto> page = new PageImpl<>(entities, pageable, entities.size());
+
+    given(foodGroupRepository.searchByKeyword(any(), any(), any(), any())).willReturn(page);
+
+    //when
+    Page<SearchedGroupDto> response = groupService.searchByKeyword(TITLE, pageable);
+
+    //then
+    verify(foodGroupRepository, times(1))
+        .searchByKeyword(any(), any(), any(), any());
+
+    assertNotNull(response);
+    assertEquals(entities.size(), response.getContent().size());
 
   }
 

--- a/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
+++ b/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 
 import com.foodmate.backend.dto.CommentDto;
 import com.foodmate.backend.dto.GroupDto;
+import com.foodmate.backend.dto.NearbyGroupDto;
 import com.foodmate.backend.dto.ReplyDto;
 import com.foodmate.backend.dto.SearchedGroupDto;
 import com.foodmate.backend.entity.ChatRoom;
@@ -982,6 +983,29 @@ public class GroupServiceTest {
 
     //then
     assertEquals(Error.FOOD_NOT_FOUND, exception.getError());
+
+  }
+
+  @Test
+  @DisplayName("내 근처 모임 성공")
+  void success_getNearbyGroupList() {
+
+    //given
+    Pageable pageable = PageRequest.of(pageNumber, pageSize);
+    List<NearbyGroupDto> entities = new ArrayList<>();
+    Page<NearbyGroupDto> page = new PageImpl<>(entities, pageable, entities.size());
+
+    given(foodGroupRepository.getNearbyGroupList(any(), any(), any(), any())).willReturn(page);
+
+    //when
+    Page<NearbyGroupDto> response = groupService.getNearbyGroupList(LATITUDE, LONGITUDE, pageable);
+
+    //then
+    verify(foodGroupRepository, times(1))
+        .getNearbyGroupList(any(), any(), any(), any());
+
+    assertNotNull(response);
+    assertEquals(entities.size(), response.getContent().size());
 
   }
 

--- a/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
+++ b/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
@@ -893,6 +893,29 @@ public class GroupServiceTest {
 
   }
 
+  @Test
+  @DisplayName("거리순 조회 성공")
+  void success_searchByLocation() {
+
+    //given
+    Pageable pageable = PageRequest.of(pageNumber, pageSize);
+    List<SearchedGroupDto> entities = new ArrayList<>();
+    Page<SearchedGroupDto> page = new PageImpl<>(entities, pageable, entities.size());
+
+    given(foodGroupRepository.searchByLocation(any(), any(), any(), any())).willReturn(page);
+
+    //when
+    Page<SearchedGroupDto> response = groupService.searchByLocation(LATITUDE, LONGITUDE, pageable);
+
+    //then
+    verify(foodGroupRepository, times(1))
+        .searchByLocation(any(), any(), any(), any());
+
+    assertNotNull(response);
+    assertEquals(entities.size(), response.getContent().size());
+
+  }
+
   private Authentication createAuthentication() {
 
     String email = "dlaehdgus23@naver.com";

--- a/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
+++ b/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
@@ -849,6 +849,28 @@ public class GroupServiceTest {
 
   }
 
+  @Test
+  @DisplayName("오늘 모임 조회 성공")
+  void success_getTodayGroupList() {
+
+    //given
+    Pageable pageable = PageRequest.of(pageNumber, pageSize);
+    List<SearchedGroupDto> entities = new ArrayList<>();
+    Page<SearchedGroupDto> page = new PageImpl<>(entities, pageable, entities.size());
+
+    given(foodGroupRepository.searchByDate(any(), any(), any())).willReturn(page);
+
+    //when
+    Page<SearchedGroupDto> response = groupService.getTodayGroupList(pageable);
+
+    //then
+    verify(foodGroupRepository, times(1)).searchByDate(any(), any(), any());
+
+    assertNotNull(response);
+    assertEquals(entities.size(), response.getContent().size());
+
+  }
+
   private Authentication createAuthentication() {
 
     String email = "dlaehdgus23@naver.com";

--- a/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
+++ b/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
@@ -1009,6 +1009,25 @@ public class GroupServiceTest {
 
   }
 
+  @Test
+  @DisplayName("로그인한 사용자가 참여한 모임 조회 성공")
+  void success_getAcceptedGroupList() {
+
+    //given
+    Authentication mockAuthentication = createAuthentication();
+    Member mockMember = createMockMember(memberId1);
+
+    given(memberRepository.findByEmail(mockAuthentication.getName())).willReturn(Optional.of(mockMember));
+
+    //when
+    groupService.getAcceptedGroupList(mockAuthentication);
+
+    //then
+    verify(enrollmentRepository, times(1))
+        .getAcceptedGroupList(any(), any(), any(), any());
+
+  }
+
   private Authentication createAuthentication() {
 
     String email = "dlaehdgus23@naver.com";

--- a/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
+++ b/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
@@ -916,6 +916,29 @@ public class GroupServiceTest {
 
   }
 
+  @Test
+  @DisplayName("날짜별 조회 성공")
+  void success_searchByDate() {
+
+    //given
+    Pageable pageable = PageRequest.of(pageNumber, pageSize);
+    List<SearchedGroupDto> entities = new ArrayList<>();
+    Page<SearchedGroupDto> page = new PageImpl<>(entities, pageable, entities.size());
+
+    given(foodGroupRepository.searchByDate(any(), any(), any())).willReturn(page);
+
+    //when
+    Page<SearchedGroupDto> response = groupService.searchByDate(
+        LocalDate.parse("2023-11-01"), LocalDate.parse("2023-11-05"), pageable);
+
+    //then
+    verify(foodGroupRepository, times(1)).searchByDate(any(), any(), any());
+
+    assertNotNull(response);
+    assertEquals(entities.size(), response.getContent().size());
+
+  }
+
   private Authentication createAuthentication() {
 
     String email = "dlaehdgus23@naver.com";


### PR DESCRIPTION
## Feature
- 그룹 API 중 댓글 대댓글 전체 조회 테스트 코드 추가하였습니다.
- 그룹 API 중 검색 기능 테스트 코드 추가하였습니다.
- 그룹 API 중 오늘 모임 조회 테스트 코드 추가하였습니다.
- 그룹 API 중 전체 모임 조회 테스트 코드 추가하였습니다.
- 그룹 API 중 거리순 조회 테스트 코드 추가하였습니다.
- 그룹 API 중 날짜별 조회 테스트 코드 추가하였습니다.
- 그룹 API 중 메뉴별 조회 테스트 코드 추가하였습니다.
- 그룹 API 중 내 근처 모임 테스트 코드 추가하였습니다.
- 그룹 API 중 현재 로그인한 사용자가 참여된 모임 Id 리스트 반환 테스트 코드 추가하였습니다.

## Test
- [x] 테스트 코드
<img width="489" alt="image" src="https://github.com/withfoodmate/backend/assets/57497745/3a67c906-8384-4f08-99e6-98cbf0719799">
