### PR TITLE
스케쥴러 생성 - 모임완료 처리 및 채팅방 삭제

### DIFF
--- a/src/main/java/com/foodmate/backend/BackendApplication.java
+++ b/src/main/java/com/foodmate/backend/BackendApplication.java
@@ -3,7 +3,9 @@ package com.foodmate.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {

--- a/src/main/java/com/foodmate/backend/component/Scheduler.java
+++ b/src/main/java/com/foodmate/backend/component/Scheduler.java
@@ -1,0 +1,60 @@
+package com.foodmate.backend.component;
+
+import com.foodmate.backend.entity.ChatRoom;
+import com.foodmate.backend.entity.FoodGroup;
+import com.foodmate.backend.enums.EnrollmentStatus;
+import com.foodmate.backend.enums.Error;
+import com.foodmate.backend.exception.ChatException;
+import com.foodmate.backend.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class Scheduler {
+
+    private final FoodGroupRepository foodGroupRepository;
+    private final EnrollmentRepository enrollmentRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMemberRepository chatMemberRepository;
+    private final ChatMessageRepository chatMessageRepository;
+//    private final SimpMessageSendingOperations sendingOperations;
+
+    @Transactional
+    @Scheduled(cron = "0 0 5 * * *")
+    public void processGroupCompletionTasks() {
+
+        log.info("Start processing Group Completion Tasks.");
+
+        LocalDateTime current = LocalDateTime.now();
+
+        // 모임완료 처리할 푸드그룹 조회
+        List<FoodGroup> groupList = foodGroupRepository.findAllByGroupDateTimeBetween(current.minusDays(1), current);
+
+        for (FoodGroup foodGroup : groupList) {
+            // 해당 모임의 수락된 Enrollment 상태를 모임완료로 일괄 변경
+            enrollmentRepository.updateStatusToGroupCompleteByFoodGroupAndStatus(foodGroup, EnrollmentStatus.ACCEPT);
+
+            ChatRoom chatRoom = chatRoomRepository.findByFoodGroupId(foodGroup.getId())
+                    .orElseThrow(() -> new ChatException(Error.CHATROOM_NOT_FOUND));
+
+            // 채팅방 구독 취소 요청
+//            sendingOperations.convertAndSend("/topic/chatroom/" + chatRoom.getId(), "모임이 완료되었습니다.");
+
+            // 채팅방 삭제 -> ChatMember, ChatMessage 먼저 삭제해야 채팅방 삭제 가능
+            chatMemberRepository.deleteAllByChatRoom(chatRoom);
+            chatMessageRepository.deleteAllByChatRoom(chatRoom);
+            chatRoomRepository.delete(chatRoom);
+        }
+
+        log.info("Finished processing Group Completion Tasks.");
+    }
+
+}

--- a/src/main/java/com/foodmate/backend/repository/ChatMemberRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/ChatMemberRepository.java
@@ -21,4 +21,7 @@ public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
     // 해당 채팅방에서 해당 멤버 삭제
     void deleteByMemberAndChatRoom(Member member, ChatRoom chatRoom);
 
+    // 해당 채팅방의 모든 데이터 삭제
+    void deleteAllByChatRoom(ChatRoom chatRoom);
+
 }

--- a/src/main/java/com/foodmate/backend/repository/ChatMessageRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/ChatMessageRepository.java
@@ -1,6 +1,5 @@
 package com.foodmate.backend.repository;
 
-import com.foodmate.backend.entity.ChatMember;
 import com.foodmate.backend.entity.ChatMessage;
 import com.foodmate.backend.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,11 +10,15 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface ChatMessageRepository extends JpaRepository<ChatMessage,Long> {
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     Optional<ChatMessage> findTopByChatRoomAndCreateDateTimeAfterOrderByCreateDateTimeDesc(ChatRoom chatRoom, LocalDateTime insertTime);
 
     int countByCreateDateTimeAfterAndChatRoom(LocalDateTime lastReadTime, ChatRoom chatRoom);
 
     List<ChatMessage> findByChatRoom_Id(Long chatRoomId);
+
+    // 해당 채팅방의 모든 데이터 삭제
+    void deleteAllByChatRoom(ChatRoom chatRoom);
+
 }

--- a/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/EnrollmentRepository.java
@@ -23,7 +23,7 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     // 모임 삭제 후 Status 상태 모임취소로 일괄 변경할 때 사용
     @Modifying
     @Query("UPDATE Enrollment e SET e.status = :status WHERE e.foodGroup.id = :groupId")
-    void changeStatusByGroupId(Long groupId, EnrollmentStatus status);
+    void updateStatusByGroupId(Long groupId, EnrollmentStatus status);
 
     // 해당 모임에 신청 이력이 존재하는지 확인
     boolean existsByMemberAndFoodGroup(Member member, FoodGroup foodGroup);
@@ -59,5 +59,10 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     // WebSocketChannelInterceptor 에서 모임참여자 검증
     boolean existsByMemberIdAndFoodGroupAndStatus(Long memberId, FoodGroup foodGroup, EnrollmentStatus status);
+
+    // 모임 완료 후 Status 가 ACCEPT 였던 신청서의 상태를 GROUP_COMPLETE 로 일괄 변경
+    @Modifying
+    @Query("UPDATE Enrollment e SET e.status = 'GROUP_COMPLETE' WHERE e.foodGroup = :foodGroup AND e.status = :status")
+    void updateStatusToGroupCompleteByFoodGroupAndStatus(FoodGroup foodGroup, EnrollmentStatus status);
 
 }

--- a/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
+++ b/src/main/java/com/foodmate/backend/repository/FoodGroupRepository.java
@@ -80,4 +80,6 @@ public interface FoodGroupRepository extends JpaRepository<FoodGroup, Long> {
             "ORDER BY FUNCTION('ST_Distance_Sphere', fg.location, :userLocation)")
     Page<NearbyGroupDto> getNearbyGroupList(Point userLocation, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
+    List<FoodGroup> findAllByGroupDateTimeBetween(LocalDateTime start, LocalDateTime end);
+
 }

--- a/src/main/java/com/foodmate/backend/service/GroupService.java
+++ b/src/main/java/com/foodmate/backend/service/GroupService.java
@@ -136,7 +136,7 @@ public class GroupService {
         foodGroupRepository.save(group);
 
         // 해당 모임에 신청한 모임신청목록들의 상태를 모임취소로 일괄 변경
-        enrollmentRepository.changeStatusByGroupId(groupId, EnrollmentStatus.GROUP_CANCEL);
+        enrollmentRepository.updateStatusByGroupId(groupId, EnrollmentStatus.GROUP_CANCEL);
     }
 
     // 특정 모임 신청

--- a/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
+++ b/src/test/java/com/foodmate/backend/service/GroupServiceTest.java
@@ -369,7 +369,7 @@ public class GroupServiceTest {
     //then
     verify(foodGroupRepository, times(1)).save(mockGroup);
     verify(enrollmentRepository, times(1))
-        .changeStatusByGroupId(groupId, EnrollmentStatus.GROUP_CANCEL);
+        .updateStatusByGroupId(groupId, EnrollmentStatus.GROUP_CANCEL);
 
   }
 


### PR DESCRIPTION
##  Feature

- 모임완료 처리 및 채팅방 삭제를 위한 스케쥴러를 생성하였습니다. ( Scheduler )

- 채팅방 삭제에 필요한 메소드를 작성하였습니다. ( ChatMemberRepository, ChatMessageRepository )

- 모임완료 처리에 필요한 메소드를 작성하였습니다. ( FoodGroupRepository, EnrollmentRepository )

- 프로젝트의 통일성을 위해 메소드명을 변경하였습니다. ( EnrollmentRepository, GroupService, GroupServiceTest )

## Test

- [ ] 테스트 코드

- DB 에서 정상적으로 작동하는 것 확인하였습니다.

![image](https://github.com/withfoodmate/backend/assets/129507835/63c6d059-6f96-4849-bc1c-0bf7a792e4f1)
